### PR TITLE
Update error handling in middlewares

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -9,6 +9,8 @@ const authRouter = require('./service/authentication');
 const rolesRouter = require('./service/roles');
 const s3Router = require('./service/s3');
 
+const { errorHandler } = require('./util/api');
+
 const app = express();
 const port = process.env.SERVER_PORT || 5000;
 
@@ -31,6 +33,15 @@ app.use(
 app.use('/auth', authRouter);
 app.use('/roles', rolesRouter);
 app.use('/media', s3Router);
+
+// This handles 404 results from router -- answers all remaining requests
+app.use((req, res, next) => {
+    const e404 = new Error('API Endpoint not found');
+    e404.status = 404;
+    next(e404);
+});
+// This handles api errors that are thrown -- needs to be after all the endpoints
+app.use(errorHandler);
 
 const listener = express();
 listener.use('/api', app);

--- a/src/server/service/roles/endpoints.js
+++ b/src/server/service/roles/endpoints.js
@@ -12,7 +12,7 @@ exports.getUserRolesAsync = async function(req, res) {
     noUserFoundError.status = 409;
 
     if (!user) {
-        return apiError(res, noUserFoundError);
+        throw noUserFoundError;
     }
 
     const userRoleData = await db.getUserRoles(userId, req.body.roles);

--- a/src/server/util/api.js
+++ b/src/server/util/api.js
@@ -27,7 +27,7 @@ exports.asyncMiddleware = middle => {
         // can have 3 arguments or 2 arguments and be treated the same
         return async function asyncMiddlewareWrapper(req, res, next) {
             try {
-                return await middle(req, res, next);
+                await middle(req, res, next);
             } catch (error) {
                 next(error);
             }
@@ -43,7 +43,7 @@ exports.asyncMiddleware = middle => {
             next
         ) {
             try {
-                return await middle(error, req, res, next);
+                await middle(error, req, res, next);
             } catch (error) {
                 next(error);
             }

--- a/src/server/util/api.js
+++ b/src/server/util/api.js
@@ -22,7 +22,9 @@ exports.asyncMiddleware = middle => {
         throw new Error('Must provide a function to asyncMiddleware');
     }
     if (middle.length == 2 || middle.length == 3) {
-        // (req, res) or (req, res, next)
+        // (req, res) or (req, res, next) -- express handles both the same, assuming
+        // middle won't call next() if it's techincally the "endpoint" so the function we return
+        // can have 3 arguments or 2 arguments and be treated the same
         return async function asyncMiddlewareWrapper(req, res, next) {
             try {
                 return await middle(req, res, next);
@@ -31,7 +33,9 @@ exports.asyncMiddleware = middle => {
             }
         };
     } else if (middle.length == 4) {
-        // (error, req, res, next)
+        // (error, req, res, next) -- middleware with 4 arguments are treated differently, they are SKIPPED
+        // when the previous request has not `next(error)` -- i.e. just `next()` would skip an error middleware
+        // so the function we return must also have 4 arguments
         return async function asyncErrorHandlingMiddlewareWrapper(
             error,
             req,

--- a/src/server/util/api.js
+++ b/src/server/util/api.js
@@ -1,5 +1,5 @@
 exports.apiError = (res, error) => {
-    const { status = 400, message } = error;
+    const { status = 500, message } = error;
     // TODO: turn on stack in DEV
     const result = {
         error: true,

--- a/src/server/util/api.js
+++ b/src/server/util/api.js
@@ -12,11 +12,41 @@ exports.apiError = (res, error) => {
     return res.status(status).json(result);
 };
 
+// error handling middleware needs 4 parameters, even though we don't use it, we MUST define it:
+// eslint-disable-next-line no-unused-vars
+exports.errorHandler = (error, req, res, next) => exports.apiError(res, error);
+
 // This function wraps around async middlewares and catches errors
-exports.asyncMiddleware = middle => async (req, res, next) => {
-    try {
-        return await middle(req, res, next);
-    } catch (error) {
-        exports.apiError(res, error);
+exports.asyncMiddleware = middle => {
+    if (typeof middle !== 'function') {
+        throw new Error('Must provide a function to asyncMiddleware');
+    }
+    if (middle.length == 2 || middle.length == 3) {
+        // (req, res) or (req, res, next)
+        return async function asyncMiddlewareWrapper(req, res, next) {
+            try {
+                return await middle(req, res, next);
+            } catch (error) {
+                next(error);
+            }
+        };
+    } else if (middle.length == 4) {
+        // (error, req, res, next)
+        return async function asyncErrorHandlingMiddlewareWrapper(
+            error,
+            req,
+            res,
+            next
+        ) {
+            try {
+                return await middle(error, req, res, next);
+            } catch (error) {
+                next(error);
+            }
+        };
+    } else {
+        throw new Error(
+            `Unknown length of function parameters - needs (req, res), (req, res, next) or (error, req, res, next) -- got: ${middle}`
+        );
     }
 };

--- a/test/server/util/api.test.js
+++ b/test/server/util/api.test.js
@@ -1,0 +1,166 @@
+const { asyncMiddleware } = require('../../../src/server/util/api');
+
+describe('util/api', () => {
+    describe('asyncMiddleware', () => {
+        test('two param middleware', async () => {
+            const mockReq = {};
+            const mockRes = {};
+
+            expect.assertions(2);
+
+            const testMiddle = async (req, res) => {
+                expect(req).toEqual(mockReq);
+                expect(res).toEqual(mockRes);
+            };
+
+            const wrapped = asyncMiddleware(testMiddle);
+
+            await wrapped(mockReq, mockRes);
+        });
+
+        test('two param middleware throws', async () => {
+            const mockReq = {};
+            const mockRes = {};
+            const mockError = new Error('mock');
+
+            expect.assertions(4);
+
+            const testMiddle = async (req, res) => {
+                expect(req).toEqual(mockReq);
+                expect(res).toEqual(mockRes);
+                throw mockError;
+            };
+
+            const mockNext = jest.fn(error => {
+                expect(error).toBe(mockError);
+            });
+
+            const wrapped = asyncMiddleware(testMiddle);
+
+            expect(wrapped.length).toBe(3);
+
+            // express will still call it with 3 params cuz asyncMiddleware gives it 3 params
+            await wrapped(mockReq, mockRes, mockNext);
+        });
+
+        test('three param middleware', async () => {
+            const mockReq = {};
+            const mockRes = {};
+            const mockNext = jest.fn();
+
+            expect.assertions(3);
+
+            const testMiddle = async (req, res, next) => {
+                expect(req).toEqual(mockReq);
+                expect(res).toEqual(mockRes);
+                expect(next).toEqual(mockNext);
+            };
+
+            const wrapped = asyncMiddleware(testMiddle);
+
+            await wrapped(mockReq, mockRes, mockNext);
+        });
+
+        test('three param middleware throws', async () => {
+            const mockReq = {};
+            const mockRes = {};
+            const mockError = new Error('mock');
+
+            expect.assertions(5);
+
+            const testMiddle = async (req, res, next) => {
+                expect(req).toEqual(mockReq);
+                expect(res).toEqual(mockRes);
+                expect(next).toEqual(mockNext);
+                throw mockError;
+            };
+
+            const mockNext = jest.fn(error => {
+                expect(error).toBe(mockError);
+            });
+
+            const wrapped = asyncMiddleware(testMiddle);
+
+            expect(wrapped.length).toBe(3);
+
+            // express will still call it with 3 params cuz asyncMiddleware gives it 3 params
+            await wrapped(mockReq, mockRes, mockNext);
+        });
+
+        test('three param middleware nexts', async () => {
+            const mockReq = {};
+            const mockRes = {};
+            const mockError = new Error('mock');
+
+            expect.assertions(5);
+
+            const testMiddle = async (req, res, next) => {
+                expect(req).toEqual(mockReq);
+                expect(res).toEqual(mockRes);
+                expect(next).toEqual(mockNext);
+                next(mockError);
+            };
+
+            const mockNext = jest.fn(error => {
+                expect(error).toBe(mockError);
+            });
+
+            const wrapped = asyncMiddleware(testMiddle);
+
+            expect(wrapped.length).toBe(3);
+
+            // express will still call it with 3 params cuz asyncMiddleware gives it 3 params
+            await wrapped(mockReq, mockRes, mockNext);
+        });
+
+        test('four param middlewares', async () => {
+            const mockReq = {};
+            const mockRes = {};
+            const mockError = new Error('mock');
+
+            expect.assertions(5);
+
+            const testMiddle = async (error, req, res, next) => {
+                expect(error).toEqual(mockError);
+                expect(req).toEqual(mockReq);
+                expect(res).toEqual(mockRes);
+                expect(next).toEqual(mockNext);
+            };
+
+            const mockNext = jest.fn(() => {
+                // this expect doesn't count toward assertions, it SHOULDNT assert
+                expect('Not called').toBe('But was');
+            });
+
+            const wrapped = asyncMiddleware(testMiddle);
+
+            expect(wrapped.length).toBe(4);
+            await wrapped(mockError, mockReq, mockRes, mockNext);
+        });
+
+        test('four param middlewares throw', async () => {
+            const mockReq = {};
+            const mockRes = {};
+            const mockError = new Error('mock');
+
+            expect.assertions(6);
+
+            const testMiddle = async (error, req, res, next) => {
+                expect(error).toEqual(mockError);
+                expect(req).toEqual(mockReq);
+                expect(res).toEqual(mockRes);
+                expect(next).toEqual(mockNext);
+                throw mockError;
+            };
+
+            const mockNext = jest.fn(error => {
+                expect(error).toBe(mockError);
+            });
+
+            const wrapped = asyncMiddleware(testMiddle);
+
+            expect(wrapped.length).toBe(4);
+            await wrapped(mockError, mockReq, mockRes, mockNext);
+        });
+    });
+});


### PR DESCRIPTION
* Using `asyncMiddleware` wrapper you just `throw error` and the error object if it has a .status will use that .status - otherwise defaulting to **500** ![500 Internal Service Error](https://http.cat/500)

* `app.use()` with a 3 param middleware (req, res, next) will catch ALL UNROUTED REQUESTS and "throw" `next(error)` a 404 error

* `app.use(errorHandler)` is a 4 param middleware (error, req, res, next) which only is called when a previous middleware has an error state, and handles sending a JSON error!