### PR TITLE
Fix relative paths without src

### DIFF
--- a/client/.storybook/webpack.config.js
+++ b/client/.storybook/webpack.config.js
@@ -28,7 +28,7 @@ module.exports = {
     resolve: {
         alias: {
             '@client': path.resolve(__dirname, '../'),
-            '@': path.resolve(__dirname, '../'),
+            '@': path.resolve(__dirname, '../..'),
             '@components': path.resolve(__dirname, '../components')
         },
         extensions: ['*', '.js', '.jsx']

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -23,7 +23,7 @@ module.exports = {
     },
     resolve: {
         alias: {
-            '@': path.resolve(__dirname, '../..'),
+            '@': path.resolve(__dirname, '..'),
             '@client': __dirname,
             '@components': path.resolve(__dirname, 'components'),
             '@server': path.resolve(__dirname, '../server')
@@ -31,7 +31,7 @@ module.exports = {
         extensions: ['*', '.js', '.jsx']
     },
     output: {
-        path: path.resolve(__dirname, '../../dist/'),
+        path: path.resolve(__dirname, '../dist/'),
         publicPath: '/dist/',
         filename: 'bundle.js'
     },

--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
     "url": "https://github.com/mit-teaching-systems-lab/threeflows/issues"
   },
   "homepage": "https://github.com/mit-teaching-systems-lab/threeflows#readme",
-  "main": "src/index.js",
+  "main": "server/index.js",
   "workspaces": [
-    "src/client",
-    "src/server",
+    "client",
+    "server",
     "test"
   ],
   "scripts": {
@@ -33,7 +33,7 @@
     "dev:server": "yarn workspace server run dev",
     "jest": "yarn workspace test run test",
     "lint": "npm-run-all \"lint:* {@}\" -c --",
-    "lint:js": "eslint --ext .json --ext .js . --ignore-pattern \"src/**/*.js\"",
+    "lint:js": "eslint --ext .json --ext .js . --ignore-pattern \"**/*.js\"",
     "lint:packages": "yarn workspaces run lint",
     "prettier": "prettier --write \"**/*.{js,jsx,json,css}\"",
     "start": "webpack-dev-server --mode development",

--- a/test/server/util/api.test.js
+++ b/test/server/util/api.test.js
@@ -1,4 +1,4 @@
-const { asyncMiddleware } = require('../../../src/server/util/api');
+const { asyncMiddleware } = require('../../../server/util/api');
 
 describe('util/api', () => {
     describe('asyncMiddleware', () => {

--- a/test/server/util/sqlHelpers.test.js
+++ b/test/server/util/sqlHelpers.test.js
@@ -1,4 +1,4 @@
-const { updateQuery } = require('../../../src/server/util/sqlHelpers');
+const { updateQuery } = require('../../../server/util/sqlHelpers');
 
 describe('sql helpers', () => {
     describe('updateQuery', () => {


### PR DESCRIPTION
I accidentally pushed a previous change to the `teacher-moments` branch (sorry!) that moved `client` and `server` out of `src` and deletes `src` since we had previously decided it was unnecessary nesting. This PR is to fix relative paths after that change. 