### PR TITLE
Hook up scenarios UI for creating new scenarios

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -28,7 +28,8 @@
         "semi": ["error", "always"],
         "eol-last": ["error", "always"],
         "no-console": ["error", { "allow": ["warn", "error"] }],
-        "no-use-before-define": ["error"]
+        "no-use-before-define": ["error"],
+        "react/display-name": ["off"]
     },
     "settings": {
         "react": {

--- a/client/components/editor/index.jsx
+++ b/client/components/editor/index.jsx
@@ -1,18 +1,16 @@
 import React from 'react';
 import { hot } from 'react-hot-loader';
 import { Tab } from 'semantic-ui-react';
-import { ScenarioEditor} from '@components/scenarioEditor';
+import ScenarioEditor from '@components/scenarioEditor';
 import { SlideEditor } from '@components/slideEditor';
 
 import './editor.css';
 
 const panes = [
-    { menuItem: 'Moment', render: ScenarioEditor},
-    { menuItem: 'Slides', render: SlideEditor}
+    { menuItem: 'Moment', render: () => <ScenarioEditor /> },
+    { menuItem: 'Slides', render: SlideEditor }
 ];
 
-const Editor = () => (
-    <Tab panes={panes} />
-);
+const Editor = () => <Tab panes={panes} />;
 
 export default hot(module)(Editor);

--- a/client/components/editor/index.jsx
+++ b/client/components/editor/index.jsx
@@ -1,13 +1,14 @@
 import React from 'react';
-import { Grid } from 'semantic-ui-react';
-import { ThumbnailContainer } from '@components/thumbnailContainer';
+import { Tab } from 'semantic-ui-react';
+import { ScenarioEditor} from '@components/scenarioEditor';
+import { SlideEditor } from '@components/slideEditor';
 import './editor.css';
 
+const panes = [
+    { menuItem: 'Moment', render: ScenarioEditor},
+    { menuItem: 'Slides', render: SlideEditor}
+];
+
 export const Editor = () => (
-    <Grid divided="vertically" className="editor">
-        <ThumbnailContainer width={4} />
-        <Grid.Column width={12} color="blue">
-            SLIDE EDITOR
-        </Grid.Column>
-    </Grid>
+    <Tab panes={panes} />
 );

--- a/client/components/editor/index.jsx
+++ b/client/components/editor/index.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
+import { hot } from 'react-hot-loader';
 import { Tab } from 'semantic-ui-react';
 import { ScenarioEditor} from '@components/scenarioEditor';
 import { SlideEditor } from '@components/slideEditor';
+
 import './editor.css';
 
 const panes = [
@@ -9,6 +11,8 @@ const panes = [
     { menuItem: 'Slides', render: SlideEditor}
 ];
 
-export const Editor = () => (
+const Editor = () => (
     <Tab panes={panes} />
 );
+
+export default hot(module)(Editor);

--- a/client/components/scenarioEditor/index.jsx
+++ b/client/components/scenarioEditor/index.jsx
@@ -1,13 +1,6 @@
 import React, { Component } from 'react';
 import { hot } from 'react-hot-loader';
-import {
-    Container,
-    Form,
-    Grid,
-    Input,
-    Label,
-    TextArea
-} from 'semantic-ui-react';
+import { Container, Form, Grid } from 'semantic-ui-react';
 
 import './ScenarioEditor.css';
 
@@ -32,7 +25,7 @@ class ScenarioEditor extends Component {
         });
     }
 
-    async handleSubmit(event) {
+    async handleSubmit() {
         if (!this.state.title || !this.state.description) {
             this.setState({
                 saveMessage:
@@ -87,8 +80,6 @@ class ScenarioEditor extends Component {
                                         className="tm__scenario-save"
                                         primary
                                         loading
-                                        left
-                                        floated
                                     />
                                 ) : (
                                     <Form.Button
@@ -96,8 +87,6 @@ class ScenarioEditor extends Component {
                                         className="tm__scenario-save"
                                         primary
                                         onClick={this.handleSubmit}
-                                        left
-                                        floated
                                     >
                                         Submit
                                     </Form.Button>

--- a/client/components/scenarioEditor/index.jsx
+++ b/client/components/scenarioEditor/index.jsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import { Container, Form, Input, Label, TextArea } from 'semantic-ui-react';
 
+import './ScenarioEditor.css';
+
 
 export const ScenarioEditor = () => (
-    <Container>
+    <Container fluid className="tm__scenario-editor">
         <h2>Teacher Moment Details</h2>
-        <Form size={'big    '}>
+        <Form size={'big'}>
             <Form.Input fluid focus required label="Title"/>
             <Form.TextArea focus label="Moment Description"/>
         </Form>

--- a/client/components/scenarioEditor/index.jsx
+++ b/client/components/scenarioEditor/index.jsx
@@ -1,15 +1,115 @@
-import React from 'react';
-import { Container, Form, Input, Label, TextArea } from 'semantic-ui-react';
+import React, { Component } from 'react';
+import { hot } from 'react-hot-loader';
+import {
+    Container,
+    Form,
+    Grid,
+    Input,
+    Label,
+    TextArea
+} from 'semantic-ui-react';
 
 import './ScenarioEditor.css';
 
+class ScenarioEditor extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            title: '',
+            description: '',
+            saving: false,
+            saveMessage: ''
+        };
 
-export const ScenarioEditor = () => (
-    <Container fluid className="tm__scenario-editor">
-        <h2>Teacher Moment Details</h2>
-        <Form size={'big'}>
-            <Form.Input fluid focus required label="Title"/>
-            <Form.TextArea focus label="Moment Description"/>
-        </Form>
-    </Container>
-);
+        this.handleChange = this.handleChange.bind(this);
+        this.handleSubmit = this.handleSubmit.bind(this);
+    }
+
+    handleChange(event) {
+        this.setState({
+            [event.target.name]: event.target.value,
+            saveMessage: ''
+        });
+    }
+
+    async handleSubmit(event) {
+        if (!this.state.title || !this.state.description) {
+            this.setState({
+                saveMessage:
+                    'A title and description are required for Teacher Moments'
+            });
+            return;
+        }
+        this.setState({ saving: true });
+        const data = JSON.stringify({
+            title: this.state.title,
+            description: this.state.description
+        });
+        const saveResponse = await (await fetch('/api/scenarios', {
+            method: 'PUT',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: data
+        })).json();
+        if (saveResponse.status === 201 || saveResponse.status === 200) {
+            this.setState({ saving: false, saveMessage: 'Saved!' });
+        } else if (saveResponse.error) {
+            this.setState({ saving: false, saveMessage: saveResponse.message });
+        }
+    }
+
+    render() {
+        return (
+            <Container fluid className="tm__scenario-editor">
+                <h2>Teacher Moment Details</h2>
+                <Form size={'big'}>
+                    <Form.Input
+                        focus
+                        required
+                        label="Title"
+                        name="title"
+                        onChange={this.handleChange}
+                    />
+                    <Form.TextArea
+                        focus
+                        required
+                        label="Moment Description"
+                        name="description"
+                        onChange={this.handleChange}
+                    />
+                    <Grid divided="vertically">
+                        <Grid.Row columns={2}>
+                            <Grid.Column width={3}>
+                                {this.state.saving ? (
+                                    <Form.Button
+                                        type="submit"
+                                        className="tm__scenario-save"
+                                        primary
+                                        loading
+                                        left
+                                        floated
+                                    />
+                                ) : (
+                                    <Form.Button
+                                        type="submit"
+                                        className="tm__scenario-save"
+                                        primary
+                                        onClick={this.handleSubmit}
+                                        left
+                                        floated
+                                    >
+                                        Submit
+                                    </Form.Button>
+                                )}
+                            </Grid.Column>
+                            <Grid.Column>{this.state.saveMessage}</Grid.Column>
+                        </Grid.Row>
+                    </Grid>
+                </Form>
+            </Container>
+        );
+    }
+}
+
+export default hot(module)(ScenarioEditor);

--- a/client/components/scenarioEditor/index.jsx
+++ b/client/components/scenarioEditor/index.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Container, Form, Input, Label, TextArea } from 'semantic-ui-react';
+
+
+export const ScenarioEditor = () => (
+    <Container>
+        <h2>Teacher Moment Details</h2>
+        <Form size={'big    '}>
+            <Form.Input fluid focus required label="Title"/>
+            <Form.TextArea focus label="Moment Description"/>
+        </Form>
+    </Container>
+);

--- a/client/components/scenarioEditor/scenarioEditor.css
+++ b/client/components/scenarioEditor/scenarioEditor.css
@@ -1,0 +1,4 @@
+.tm__scenario-editor {
+    margin: 1rem;
+    padding: 1rem;
+}

--- a/client/components/scenarioEditor/scenarioEditor.css
+++ b/client/components/scenarioEditor/scenarioEditor.css
@@ -2,3 +2,7 @@
     margin: 1rem;
     padding: 1rem;
 }
+
+.tm__scenario-save {
+    margin: 1rem 0;
+}

--- a/client/components/slideEditor/index.jsx
+++ b/client/components/slideEditor/index.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Grid } from 'semantic-ui-react';
+import { ThumbnailContainer } from '@components/thumbnailContainer';
+
+export const SlideEditor = () => (
+    <Grid divided="vertically" className="editor">
+        <ThumbnailContainer width={4} />
+        <Grid.Column width={12} color="blue">
+            SLIDE EDITOR
+        </Grid.Column>
+    </Grid>
+);

--- a/client/routes/index.jsx
+++ b/client/routes/index.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Route, NavLink, BrowserRouter as Router } from 'react-router-dom';
 
 import App from '@client/components/app';
+import Editor from '@client/components/editor';
 import Login from '@client/components/login';
 
 function Routes() {
@@ -16,6 +17,9 @@ function Routes() {
                         <NavLink to="/login">Login</NavLink>
                     </li>
                     <li>
+                        <NavLink to="/editor">TM Editor</NavLink>
+                    </li>
+                    <li>
                         <a href="https://github.com/mit-teaching-systems-lab/threeflows">
                             Source Code
                         </a>
@@ -24,6 +28,7 @@ function Routes() {
 
                 <hr />
                 <Route path="/" component={App} />
+                <Route path="/editor" component={Editor} />
                 <Route path="/login" component={Login} />
             </div>
         </Router>

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -18,6 +18,11 @@ module.exports = {
             {
                 test: /\.css$/,
                 use: ['style-loader', 'css-loader']
+            },
+            {
+                // From https://github.com/Semantic-Org/Semantic-UI-CSS/issues/28
+                test: /\.(png|woff|woff2|eot|ttf|svg)$/,
+                loader: 'url-loader?limit=100000'
             }
         ]
     },

--- a/server/service/scenarios/endpoints.js
+++ b/server/service/scenarios/endpoints.js
@@ -24,7 +24,8 @@ exports.addScenario = asyncMiddleware(async function addScenarioAsync(
     req,
     res
 ) {
-    const { userId, title, description } = req.body;
+    const userId = req.session.user.id;
+    const { title, description } = req.body;
 
     if (!userId || !title || !description) {
         const scenarioCreateError = new Error(


### PR DESCRIPTION
@gnarf this PR adds the editor components in the front end as tabs and hooks up the scenario title and description fields to the API to save new entries.

![Screen Shot 2019-10-01 at 11 37 47 AM](https://user-images.githubusercontent.com/7991694/65977500-07b73d80-e440-11e9-87c3-83ddf7cbcfa9.png)

I have also added some front end error handling, since we prevent saving scenarios without a title and description in the database currently. One thing to note: This doesn't tackle editing an existing post currently, so switching to the slides tab or another page will make you loose your scenario content in the "Moment" tab. Open to suggestions to handling that (or anything) better though!