### PR TITLE
Create account UI

### DIFF
--- a/client/components/createAccount/index.jsx
+++ b/client/components/createAccount/index.jsx
@@ -1,8 +1,9 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 import { Button, Form, Grid } from 'semantic-ui-react';
 
-import { logIn, logOut } from '@client/actions';
+import { logIn } from '@client/actions';
 
 class CreateAccount extends Component {
     constructor(props) {
@@ -138,14 +139,23 @@ class CreateAccount extends Component {
     }
 }
 
+CreateAccount.propTypes = {
+    history: PropTypes.shape({
+        push: PropTypes.func.isRequired
+    }).isRequired,
+    logIn: PropTypes.func.isRequired,
+    logOut: PropTypes.func.isRequired,
+    isLoggedIn: PropTypes.bool.isRequired,
+    username: PropTypes.string
+};
+
 function mapStateToProps(state) {
     const { isLoggedIn, username } = state.login;
     return { isLoggedIn, username };
 }
 
 const mapDispatchToProps = {
-    logIn,
-    logOut
+    logIn
 };
 
 export default connect(

--- a/client/components/createAccount/index.jsx
+++ b/client/components/createAccount/index.jsx
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 import { Button, Form, Grid } from 'semantic-ui-react';
 
 class CreateAccount extends Component {
@@ -11,7 +10,7 @@ class CreateAccount extends Component {
             passwordInput: '',
             confirmPasswordInput: '',
             createError: ''
-        }
+        };
 
         this.validFormInput = this.validFormInput.bind(this);
         this.handleSubmit = this.handleSubmit.bind(this);
@@ -20,17 +19,25 @@ class CreateAccount extends Component {
 
     validFormInput() {
         if (!this.state.passwordInput || !this.state.confirmPasswordInput) {
-            this.setState({createError: 'Please enter and confirm your intended password.'});
+            this.setState({
+                createError: 'Please enter and confirm your intended password.'
+            });
             return false;
         }
 
         if (this.state.passwordInput !== this.state.confirmPasswordInput) {
-            this.setState({createError: 'Password fields do not match. Please confirm your intended password.'});
+            this.setState({
+                createError:
+                    'Password fields do not match. Please confirm your intended password.'
+            });
             return false;
         }
 
         if (!this.state.username && this.state.email) {
-            this.setState({createError: 'Please enter a username or email address for your account.'});
+            this.setState({
+                createError:
+                    'Please enter a username or email address for your account.'
+            });
             return false;
         }
 
@@ -38,7 +45,7 @@ class CreateAccount extends Component {
     }
 
     async handleSubmit() {
-        if (! this.validFormInput()) {
+        if (!this.validFormInput()) {
             return;
         }
         const data = JSON.stringify({
@@ -53,18 +60,17 @@ class CreateAccount extends Component {
             },
             body: data
         })).json();
-        console.log(createResponse)
-        if (createResponse.error) {
-            this.setState({createError: createResponse.message});
-        }
 
+        if (createResponse.error) {
+            this.setState({ createError: createResponse.message });
+        }
     }
 
     handleChange(event) {
         if (this.state.createError) {
-            this.setState({createError: ''});
+            this.setState({ createError: '' });
         }
-        this.setState({[`${event.target.name}Input`]: event.target.value});
+        this.setState({ [`${event.target.name}Input`]: event.target.value });
     }
 
     render() {

--- a/client/components/createAccount/index.jsx
+++ b/client/components/createAccount/index.jsx
@@ -1,5 +1,8 @@
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import { Button, Form, Grid } from 'semantic-ui-react';
+
+import { logIn, logOut } from '@client/actions';
 
 class CreateAccount extends Component {
     constructor(props) {
@@ -9,7 +12,7 @@ class CreateAccount extends Component {
             emailInput: '',
             passwordInput: '',
             confirmPasswordInput: '',
-            createError: ''
+            createMessage: ''
         };
 
         this.validFormInput = this.validFormInput.bind(this);
@@ -20,14 +23,15 @@ class CreateAccount extends Component {
     validFormInput() {
         if (!this.state.passwordInput || !this.state.confirmPasswordInput) {
             this.setState({
-                createError: 'Please enter and confirm your intended password.'
+                createMessage:
+                    'Please enter and confirm your intended password.'
             });
             return false;
         }
 
         if (this.state.passwordInput !== this.state.confirmPasswordInput) {
             this.setState({
-                createError:
+                createMessage:
                     'Password fields do not match. Please confirm your intended password.'
             });
             return false;
@@ -35,7 +39,7 @@ class CreateAccount extends Component {
 
         if (!this.state.username && this.state.email) {
             this.setState({
-                createError:
+                createMessage:
                     'Please enter a username or email address for your account.'
             });
             return false;
@@ -62,13 +66,17 @@ class CreateAccount extends Component {
         })).json();
 
         if (createResponse.error) {
-            this.setState({ createError: createResponse.message });
+            this.setState({ createMessage: createResponse.message });
+            return;
         }
+
+        this.props.logIn(createResponse.user.username);
+        this.props.history.push('/');
     }
 
     handleChange(event) {
-        if (this.state.createError) {
-            this.setState({ createError: '' });
+        if (this.state.createMessage) {
+            this.setState({ createMessage: '' });
         }
         this.setState({ [`${event.target.name}Input`]: event.target.value });
     }
@@ -123,11 +131,24 @@ class CreateAccount extends Component {
                             Create Account
                         </Button>
                     </Grid.Column>
-                    <Grid.Column>{this.state.createError}</Grid.Column>
+                    <Grid.Column>{this.state.createMessage}</Grid.Column>
                 </Grid>
             </Form>
         );
     }
 }
 
-export default CreateAccount;
+function mapStateToProps(state) {
+    const { isLoggedIn, username } = state.login;
+    return { isLoggedIn, username };
+}
+
+const mapDispatchToProps = {
+    logIn,
+    logOut
+};
+
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(CreateAccount);

--- a/client/components/createAccount/index.jsx
+++ b/client/components/createAccount/index.jsx
@@ -1,0 +1,127 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { Button, Form, Grid } from 'semantic-ui-react';
+
+class CreateAccount extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            usernameInput: '',
+            emailInput: '',
+            passwordInput: '',
+            confirmPasswordInput: '',
+            createError: ''
+        }
+
+        this.validFormInput = this.validFormInput.bind(this);
+        this.handleSubmit = this.handleSubmit.bind(this);
+        this.handleChange = this.handleChange.bind(this);
+    }
+
+    validFormInput() {
+        if (!this.state.passwordInput || !this.state.confirmPasswordInput) {
+            this.setState({createError: 'Please enter and confirm your intended password.'});
+            return false;
+        }
+
+        if (this.state.passwordInput !== this.state.confirmPasswordInput) {
+            this.setState({createError: 'Password fields do not match. Please confirm your intended password.'});
+            return false;
+        }
+
+        if (!this.state.username && this.state.email) {
+            this.setState({createError: 'Please enter a username or email address for your account.'});
+            return false;
+        }
+
+        return true;
+    }
+
+    async handleSubmit() {
+        if (! this.validFormInput()) {
+            return;
+        }
+        const data = JSON.stringify({
+            username: this.state.usernameInput,
+            email: this.state.emailInput,
+            password: this.state.passwordInput
+        });
+        const createResponse = await (await fetch('/api/auth/signup', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: data
+        })).json();
+        console.log(createResponse)
+        if (createResponse.error) {
+            this.setState({createError: createResponse.message});
+        }
+
+    }
+
+    handleChange(event) {
+        if (this.state.createError) {
+            this.setState({createError: ''});
+        }
+        this.setState({[`${event.target.name}Input`]: event.target.value});
+    }
+
+    render() {
+        return (
+            <Form className="signup__form">
+                <Form.Field>
+                    <label htmlFor="name">Username</label>
+                    <input
+                        name="username"
+                        onChange={event => this.handleChange(event)}
+                        value={this.state.usernameInput}
+                    />
+                </Form.Field>
+                <Form.Field>
+                    <label htmlFor="email">Email Address</label>
+                    <input
+                        name="email"
+                        onChange={event => this.handleChange(event)}
+                        value={this.state.emailInput}
+                    />
+                </Form.Field>
+                <Form.Field>
+                    <label htmlFor="password">Password</label>
+                    <input
+                        name="password"
+                        type="password"
+                        required
+                        onChange={event => this.handleChange(event)}
+                        value={this.state.passwordInput}
+                    />
+                </Form.Field>
+                <Form.Field>
+                    <label htmlFor="confirmPassword">Confirm Password</label>
+                    <input
+                        name="confirmPassword"
+                        type="password"
+                        required
+                        onChange={event => this.handleChange(event)}
+                        value={this.state.confirmPasswordInput}
+                    />
+                </Form.Field>
+                <Grid columns={2}>
+                    <Grid.Column>
+                        <Button
+                            type="submit"
+                            primary
+                            size="large"
+                            onClick={this.handleSubmit}
+                        >
+                            Create Account
+                        </Button>
+                    </Grid.Column>
+                    <Grid.Column>{this.state.createError}</Grid.Column>
+                </Grid>
+            </Form>
+        );
+    }
+}
+
+export default CreateAccount;

--- a/client/components/editor/editor.css
+++ b/client/components/editor/editor.css
@@ -1,5 +1,8 @@
-.editor,
-#root {
-    height: 100%;
-    width: 100%;
+.login__form {
+    margin: 1rem;
+}
+
+.login__form--create-link {
+    margin-top: 1rem;
+    font-size: 1.1rem;
 }

--- a/client/components/login/index.jsx
+++ b/client/components/login/index.jsx
@@ -6,11 +6,6 @@ import { Button, Form, Grid, Item } from 'semantic-ui-react';
 
 import { logIn, logOut } from '@client/actions';
 
-const mapDispatchToProps = {
-    logIn,
-    logOut
-};
-
 class Login extends Component {
     constructor(props) {
         super(props);
@@ -24,21 +19,12 @@ class Login extends Component {
         };
 
         this.handleChange = this.handleChange.bind(this);
-        this.handleSubmit = this.handleSubmit.bind(this);
         this.handleLogIn = this.handleLogIn.bind(this);
         this.handleLogOut = this.handleLogOut.bind(this);
     }
 
     handleChange(event) {
         this.setState({ [`${event.target.name}Input`]: event.target.value });
-    }
-
-    handleSubmit() {
-        if (this.props.isLoggedIn) {
-            this.handleLogOut();
-        } else {
-            this.handleLogIn();
-        }
     }
 
     async handleLogIn() {
@@ -77,6 +63,19 @@ class Login extends Component {
     }
 
     render() {
+        if (this.props.isLoggedIn) {
+            return (
+                <Button
+                    type="submit"
+                    primary
+                    size="large"
+                    onClick={this.handleLogOut}
+                >
+                    Sign Out
+                </Button>
+            );
+        }
+
         return (
             <Form className="login__form">
                 <Form.Field>
@@ -104,11 +103,9 @@ class Login extends Component {
                                     type="submit"
                                     primary
                                     size="large"
-                                    onClick={this.handleSubmit}
+                                    onClick={this.handleLogIn}
                                 >
-                                    {this.props.isLoggedIn
-                                        ? 'Sign Out'
-                                        : 'Sign In'}
+                                    Sign In
                                 </Button>
                             </Item.Extra>
                             <Item.Extra className="login__form--create-link">
@@ -134,6 +131,12 @@ function mapStateToProps(state) {
     const { isLoggedIn, username } = state.login;
     return { isLoggedIn, username };
 }
+
+const mapDispatchToProps = {
+    logIn,
+    logOut
+};
+
 export default connect(
     mapStateToProps,
     mapDispatchToProps

--- a/client/components/login/index.jsx
+++ b/client/components/login/index.jsx
@@ -1,6 +1,8 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
+import { Button, Form, Grid, Item } from 'semantic-ui-react';
 
 import { logIn, logOut } from '@client/actions';
 
@@ -16,18 +18,26 @@ class Login extends Component {
         this.state = {
             isLoggedIn: false,
             loginError: '',
+            buttonText: 'Login',
             username: '',
-            usernameInput: ''
+            usernameInput: '',
+            passwordInput: ''
         };
 
-        this.updateUsernameInput = this.updateUsernameInput.bind(this);
+        this.handleChange = this.handleChange.bind(this);
+        this.handleSubmit = this.handleSubmit.bind(this);
+        this.handleSignUp = this.handleSignUp.bind(this);
         this.handleLogIn = this.handleLogIn.bind(this);
         this.handleLogOut = this.handleLogOut.bind(this);
     }
 
-    updateUsernameInput(usernameInput) {
-        this.setState({ usernameInput });
+    handleChange(event) {
+        this.setState({ [`${event.target.name}Input`]: event.target.value });
     }
+
+    handleSubmit(event) {}
+
+    handleSignUp() {}
 
     async handleLogIn() {
         const data = JSON.stringify({ username: this.state.usernameInput });
@@ -63,26 +73,45 @@ class Login extends Component {
 
     render() {
         return (
-            <div>
-                <div>
-                    <label htmlFor="name">username</label>
+            <Form className="login__form">
+                <Form.Field>
+                    <label htmlFor="name">Username</label>
                     <input
                         name="username"
-                        onChange={e => this.updateUsernameInput(e.target.value)}
+                        onChange={event => this.handleChange(event)}
                         value={this.state.usernameInput}
                     />
-                </div>
-                <div>
-                    <button onClick={this.handleLogIn}>Login</button>
-                    <button onClick={this.handleLogOut}>Logout</button>
-                </div>
-                {this.props.isLoggedIn ? (
-                    <p>Username: {this.props.username}</p>
-                ) : (
-                    <p>Not logged in</p>
-                )}
-                {this.state.loginError}
-            </div>
+                </Form.Field>
+                <Form.Field>
+                    <label htmlFor="password">Password</label>
+                    <input
+                        name="password"
+                        type="password"
+                        onChange={event => this.handleChange(event)}
+                        value={this.state.passwordInput}
+                    />
+                </Form.Field>
+                <Grid columns={2}>
+                    <Grid.Column>
+                        <Item>
+                            <Item.Extra>
+                                <Button
+                                    type="submit"
+                                    primary
+                                    size="large"
+                                    onClick={this.handleSubmit()}
+                                >
+                                    {this.state.buttonText}
+                                </Button>
+                            </Item.Extra>
+                            <Item.Extra className="login__form--create-link">
+                                <Link to="/login/new">Create an account</Link>
+                            </Item.Extra>
+                        </Item>
+                    </Grid.Column>
+                    <Grid.Column>{this.state.loginError}</Grid.Column>
+                </Grid>
+            </Form>
         );
     }
 }

--- a/client/components/login/index.jsx
+++ b/client/components/login/index.jsx
@@ -18,7 +18,6 @@ class Login extends Component {
         this.state = {
             isLoggedIn: false,
             loginError: '',
-            buttonText: 'Login',
             username: '',
             usernameInput: '',
             passwordInput: ''
@@ -26,7 +25,6 @@ class Login extends Component {
 
         this.handleChange = this.handleChange.bind(this);
         this.handleSubmit = this.handleSubmit.bind(this);
-        this.handleSignUp = this.handleSignUp.bind(this);
         this.handleLogIn = this.handleLogIn.bind(this);
         this.handleLogOut = this.handleLogOut.bind(this);
     }
@@ -35,12 +33,16 @@ class Login extends Component {
         this.setState({ [`${event.target.name}Input`]: event.target.value });
     }
 
-    handleSubmit(event) {}
-
-    handleSignUp() {}
+    handleSubmit() {
+        if (this.props.isLoggedIn) {
+            this.handleLogOut();
+        } else {
+            this.handleLogIn();
+        }
+    }
 
     async handleLogIn() {
-        const data = JSON.stringify({ username: this.state.usernameInput });
+        const data = JSON.stringify({ username: this.state.usernameInput, password: this.state.passwordInput });
         const loginResponse = await (await fetch('/api/auth/login', {
             method: 'POST',
             headers: {
@@ -99,9 +101,9 @@ class Login extends Component {
                                     type="submit"
                                     primary
                                     size="large"
-                                    onClick={this.handleSubmit()}
+                                    onClick={this.handleSubmit}
                                 >
-                                    {this.state.buttonText}
+                                    {this.props.isLoggedIn ? "Sign Out" : "Sign In"}
                                 </Button>
                             </Item.Extra>
                             <Item.Extra className="login__form--create-link">

--- a/client/components/login/index.jsx
+++ b/client/components/login/index.jsx
@@ -42,7 +42,10 @@ class Login extends Component {
     }
 
     async handleLogIn() {
-        const data = JSON.stringify({ username: this.state.usernameInput, password: this.state.passwordInput });
+        const data = JSON.stringify({
+            username: this.state.usernameInput,
+            password: this.state.passwordInput
+        });
         const loginResponse = await (await fetch('/api/auth/login', {
             method: 'POST',
             headers: {
@@ -103,7 +106,9 @@ class Login extends Component {
                                     size="large"
                                     onClick={this.handleSubmit}
                                 >
-                                    {this.props.isLoggedIn ? "Sign Out" : "Sign In"}
+                                    {this.props.isLoggedIn
+                                        ? 'Sign Out'
+                                        : 'Sign In'}
                                 </Button>
                             </Item.Extra>
                             <Item.Extra className="login__form--create-link">

--- a/client/components/scenariosList/index.jsx
+++ b/client/components/scenariosList/index.jsx
@@ -70,7 +70,8 @@ class ScenariosList extends Component {
 }
 
 ScenariosList.propTypes = {
-    scenarioData: PropTypes.array
+    scenarioData: PropTypes.array,
+    isLoggedIn: PropTypes.bool.isRequired
 };
 
 function mapStateToProps(state) {

--- a/client/components/scenariosList/index.jsx
+++ b/client/components/scenariosList/index.jsx
@@ -1,11 +1,12 @@
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { Button, Container, List } from 'semantic-ui-react';
 import PropTypes from 'prop-types';
 
 import 'semantic-ui-css/semantic.min.css';
 
-const ScenarioEntries = ({ scenarioData }) => {
+const ScenarioEntries = ({ scenarioData, isLoggedIn }) => {
     if (!scenarioData.length) {
         return null;
     }
@@ -13,16 +14,18 @@ const ScenarioEntries = ({ scenarioData }) => {
     return scenarioData.map(({ id, title, description }) => {
         return (
             <List.Item fluid="true" key={id}>
-                <Button
-                    basic
-                    floated="right"
-                    color="black"
-                    as={Link}
-                    push="true"
-                    to={{ pathname: `/editor/${id}` }}
-                >
-                    Edit
-                </Button>
+                {isLoggedIn && (
+                    <Button
+                        basic
+                        floated="right"
+                        color="black"
+                        as={Link}
+                        push="true"
+                        to={{ pathname: `/editor/${id}` }}
+                    >
+                        Edit
+                    </Button>
+                )}
                 <List.Header as="h3">{title}</List.Header>
                 <List.Content>{description}</List.Content>
             </List.Item>
@@ -56,7 +59,10 @@ class ScenariosList extends Component {
             <Container>
                 <h2>Practice spaces for teacher preparation programs</h2>
                 <List relaxed>
-                    <ScenarioEntries scenarioData={this.state.scenarioData} />
+                    <ScenarioEntries
+                        scenarioData={this.state.scenarioData}
+                        isLoggedIn={this.props.isLoggedIn}
+                    />
                 </List>
             </Container>
         );
@@ -67,4 +73,12 @@ ScenariosList.propTypes = {
     scenarioData: PropTypes.array
 };
 
-export default ScenariosList;
+function mapStateToProps(state) {
+    const { isLoggedIn, username } = state.login;
+    return { isLoggedIn, username };
+}
+
+export default connect(
+    mapStateToProps,
+    null
+)(ScenariosList);

--- a/client/routes/index.jsx
+++ b/client/routes/index.jsx
@@ -4,6 +4,7 @@ import { Route, NavLink, BrowserRouter as Router } from 'react-router-dom';
 import App from '@client/components/app';
 import Editor from '@client/components/editor';
 import Login from '@client/components/login';
+import CreateAccount from '@client/components/createAccount';
 
 function Routes() {
     return (
@@ -31,7 +32,8 @@ function Routes() {
 
                 <Route exact path="/" component={App} />
                 <Route path="/editor/:id" component={Editor} />
-                <Route path="/login" component={Login} />
+                <Route exact path="/login" component={Login} />
+                <Route path="/login/new" component={CreateAccount} />
             </div>
         </Router>
     );

--- a/server/service/authentication.js
+++ b/server/service/authentication.js
@@ -1,5 +1,4 @@
 const { Router } = require('express');
-const cors = require('cors');
 const {
     createUser,
     duplicatedUser,

--- a/server/service/authentication.js
+++ b/server/service/authentication.js
@@ -17,16 +17,21 @@ authRouter.post('/signup', [
     validateRequestBody,
     validateRequestUsernameAndEmail,
     duplicatedUser,
-    createUser
+    createUser,
+    (req, res) => {
+        res.json({user: req.session.user});
+    }
 ]);
 
 authRouter.post(
-    '/login',
-    [cors(), validateRequestBody, validateRequestUsernameAndEmail, loginUser],
-    (req, res) => {
-        res.json(req.session.user);
-    }
-);
+    '/login', [
+        validateRequestBody,
+        validateRequestUsernameAndEmail,
+        loginUser,
+        (req, res) => {
+            res.json(req.session.user);
+        }
+]);
 
 authRouter.post('/logout', (req, res) => {
     delete req.session.user;

--- a/server/service/authentication.js
+++ b/server/service/authentication.js
@@ -19,18 +19,17 @@ authRouter.post('/signup', [
     duplicatedUser,
     createUser,
     (req, res) => {
-        res.json({user: req.session.user});
+        res.json({ user: req.session.user });
     }
 ]);
 
-authRouter.post(
-    '/login', [
-        validateRequestBody,
-        validateRequestUsernameAndEmail,
-        loginUser,
-        (req, res) => {
-            res.json(req.session.user);
-        }
+authRouter.post('/login', [
+    validateRequestBody,
+    validateRequestUsernameAndEmail,
+    loginUser,
+    (req, res) => {
+        res.json(req.session.user);
+    }
 ]);
 
 authRouter.post('/logout', (req, res) => {

--- a/server/service/scenarios/db.js
+++ b/server/service/scenarios/db.js
@@ -9,7 +9,9 @@ exports.getScenario = async function getScenario(scenarioId) {
 };
 
 exports.getAllScenarios = async function getAllScenarios() {
-    const results = await query(sql`SELECT * FROM scenario;`);
+    const results = await query(
+        sql`SELECT * FROM scenario ORDER BY created_at DESC;`
+    );
     return results.rows;
 };
 

--- a/server/util/authenticationHelpers.js
+++ b/server/util/authenticationHelpers.js
@@ -138,7 +138,7 @@ const createUserBackend = async function(req, res, next) {
         email: created.email,
         id: created.id
     };
-    // res.status(201);
+
     next();
 };
 


### PR DESCRIPTION
I fixed the previous errors that I was running into! The proposed changes now in this PR:

- Use Semantic UI for the login UI
- Add a component to create an account in the front end, hits auth API to add user in the database
- Some tweaks on the backend to fix some errors, clean up code

One downside I'm finding is that a user isn't staying logged in if I refresh the page. That can be tackled in another PR though

Login form
![Screen Shot 2019-10-10 at 3 35 32 PM](https://user-images.githubusercontent.com/7991694/66600520-b14eab00-eb73-11e9-8f14-f55750f4ee76.png)

Create account form
![Screen Shot 2019-10-10 at 3 35 50 PM](https://user-images.githubusercontent.com/7991694/66600554-c0355d80-eb73-11e9-88f3-dcbe60aff7cd.png)
