### PR TITLE
Basic persistance for logged in users.

### DIFF
--- a/client/components/createAccount/index.jsx
+++ b/client/components/createAccount/index.jsx
@@ -17,8 +17,8 @@ class CreateAccount extends Component {
         };
 
         this.validFormInput = this.validFormInput.bind(this);
-        this.handleSubmit = this.handleSubmit.bind(this);
-        this.handleChange = this.handleChange.bind(this);
+        this.onSubmit = this.onSubmit.bind(this);
+        this.onChange = this.onChange.bind(this);
     }
 
     validFormInput() {
@@ -49,7 +49,7 @@ class CreateAccount extends Component {
         return true;
     }
 
-    async handleSubmit() {
+    async onSubmit() {
         if (!this.validFormInput()) {
             return;
         }
@@ -75,7 +75,7 @@ class CreateAccount extends Component {
         this.props.history.push('/');
     }
 
-    handleChange(event) {
+    onChange(event) {
         if (this.state.createMessage) {
             this.setState({ createMessage: '' });
         }
@@ -89,7 +89,7 @@ class CreateAccount extends Component {
                     <label htmlFor="name">Username</label>
                     <input
                         name="username"
-                        onChange={event => this.handleChange(event)}
+                        onChange={event => this.onChange(event)}
                         value={this.state.usernameInput}
                     />
                 </Form.Field>
@@ -97,7 +97,7 @@ class CreateAccount extends Component {
                     <label htmlFor="email">Email Address</label>
                     <input
                         name="email"
-                        onChange={event => this.handleChange(event)}
+                        onChange={event => this.onChange(event)}
                         value={this.state.emailInput}
                     />
                 </Form.Field>
@@ -107,7 +107,7 @@ class CreateAccount extends Component {
                         name="password"
                         type="password"
                         required
-                        onChange={event => this.handleChange(event)}
+                        onChange={event => this.onChange(event)}
                         value={this.state.passwordInput}
                     />
                 </Form.Field>
@@ -117,7 +117,7 @@ class CreateAccount extends Component {
                         name="confirmPassword"
                         type="password"
                         required
-                        onChange={event => this.handleChange(event)}
+                        onChange={event => this.onChange(event)}
                         value={this.state.confirmPasswordInput}
                     />
                 </Form.Field>
@@ -127,7 +127,7 @@ class CreateAccount extends Component {
                             type="submit"
                             primary
                             size="large"
-                            onClick={this.handleSubmit}
+                            onClick={this.onSubmit}
                         >
                             Create Account
                         </Button>

--- a/client/components/scenariosList/index.jsx
+++ b/client/components/scenariosList/index.jsx
@@ -19,8 +19,8 @@ const ScenarioEntries = ({ scenarioData, isLoggedIn }) => {
                         basic
                         floated="right"
                         color="black"
-                        as={Link}
                         push="true"
+                        as={Link}
                         to={{ pathname: `/editor/${id}` }}
                     >
                         Edit

--- a/client/index.js
+++ b/client/index.js
@@ -5,11 +5,13 @@ import { Provider } from 'react-redux';
 import Routes from '@client/routes';
 import store from '@client/store';
 
-const rootEl = document.getElementById('root');
+import Session from '@client/util/session';
+
+Session.timeout();
 
 ReactDOM.render(
     <Provider store={store}>
         <Routes />
     </Provider>,
-    rootEl
+    document.getElementById('root')
 );

--- a/client/reducers/login.js
+++ b/client/reducers/login.js
@@ -1,7 +1,10 @@
 import { LOG_IN, LOG_OUT } from '@client/actions/types';
+import Session from '@client/util/session';
 
+const { username = '' } = Session.isSessionActive() ? Session.getSession() : {};
 const initialState = {
-    isLoggedIn: false
+    isLoggedIn: !!username,
+    username
 };
 
 export default function(state = initialState, action) {

--- a/client/routes/index.jsx
+++ b/client/routes/index.jsx
@@ -6,6 +6,10 @@ import Editor from '@client/components/editor';
 import Login from '@client/components/login';
 import CreateAccount from '@client/components/createAccount';
 
+import Session from '@client/util/session';
+
+Session.timeout();
+
 function Routes() {
     return (
         <Router>
@@ -19,7 +23,11 @@ function Routes() {
                         <NavLink to="/editor/new">TM Editor</NavLink>
                     </li>
                     <li>
-                        <NavLink to="/login">Login</NavLink>
+                        {Session.isSessionActive() ? (
+                            <NavLink to="/logout">Log out</NavLink>
+                        ) : (
+                            <NavLink to="/login">Log in</NavLink>
+                        )}
                     </li>
                     <li>
                         <a href="https://github.com/mit-teaching-systems-lab/threeflows">
@@ -32,6 +40,7 @@ function Routes() {
 
                 <Route exact path="/" component={App} />
                 <Route path="/editor/:id" component={Editor} />
+                <Route exact path="/logout" component={Login} />
                 <Route exact path="/login" component={Login} />
                 <Route path="/login/new" component={CreateAccount} />
             </div>

--- a/client/util/session.js
+++ b/client/util/session.js
@@ -1,0 +1,46 @@
+const TIMEOUT = 1000 * 60 * 60;
+
+const getSession = () => {
+    const { timestamp = Date.now(), username = '' } = JSON.parse(
+        localStorage.getItem('session')
+    ) || {
+        timestamp: '',
+        username: ''
+    };
+
+    return {
+        timestamp,
+        username
+    };
+};
+
+const isSessionActive = () => {
+    const { timestamp } = getSession();
+    return Number(timestamp) >= Date.now() - TIMEOUT;
+};
+
+const isLoggedIn = () => {
+    const { username } = getSession();
+    return isSessionActive() && username !== '';
+};
+
+const destroy = () => {
+    localStorage.removeItem('session');
+};
+
+const create = session => {
+    localStorage.setItem('session', JSON.stringify(session));
+};
+
+export default {
+    create,
+    destroy,
+    getSession,
+    isLoggedIn,
+    isSessionActive,
+    timeout() {
+        if (!isSessionActive()) {
+            destroy();
+        }
+    }
+};

--- a/server/service/authentication.js
+++ b/server/service/authentication.js
@@ -3,7 +3,8 @@ const {
     createUser,
     duplicatedUser,
     loginUser,
-    requireUser
+    requireUser,
+    respondWithUser
 } = require('../util/authenticationHelpers');
 const {
     validateRequestUsernameAndEmail,
@@ -12,32 +13,26 @@ const {
 
 const authRouter = Router();
 
+authRouter.get('/me', requireUser, respondWithUser);
+
 authRouter.post('/signup', [
     validateRequestBody,
     validateRequestUsernameAndEmail,
     duplicatedUser,
     createUser,
-    (req, res) => {
-        res.json({ user: req.session.user });
-    }
+    respondWithUser
 ]);
 
 authRouter.post('/login', [
     validateRequestBody,
     validateRequestUsernameAndEmail,
     loginUser,
-    (req, res) => {
-        res.json(req.session.user);
-    }
+    respondWithUser
 ]);
 
 authRouter.post('/logout', (req, res) => {
     delete req.session.user;
     req.session.destroy(() => res.send('ok'));
-});
-
-authRouter.get('/me', requireUser, (req, res) => {
-    return res.json(req.session.user);
 });
 
 module.exports = authRouter;

--- a/server/util/authenticationHelpers.js
+++ b/server/util/authenticationHelpers.js
@@ -155,10 +155,15 @@ const requireUser = (req, res, next) => {
     next();
 };
 
+const respondWithUser = (req, res) => {
+    return res.json(req.session.user);
+};
+
 module.exports = {
     createUser,
     duplicatedUser,
+    getUserById,
     loginUser,
     requireUser,
-    getUserById
+    respondWithUser
 };


### PR DESCRIPTION
@gnarf this will persist a user after they log in, but I didn't have time to fix `client/routes/index.jsx` so that it displayed "Log in" or "Log out" (depending on the state) without a full refresh of the page. 

- The next step is to upgrade this to use JSON web tokens: 
    - Create `jwt` on log-in or sign-up, 
    - Respond with `jwt` in `res.session.user`
    - Store `jwt` in `localStorage` for some period of time (encrypted?)
    - Send `jwt` in headers for all requests that need authorization


For now, this gets us basic persistence across refreshes, reloads and new tabs. Any changes that need to be made will likely have to be made directly as new commits—I can't guarantee that I will have time to do follow ups from reviews. 
