### PR TITLE
Switch to slides tab when saving new scenario

### DIFF
--- a/client/components/Editor/index.jsx
+++ b/client/components/Editor/index.jsx
@@ -15,7 +15,7 @@ class Editor extends Component {
         super(props);
 
         this.state = {
-            isNewPost: this.props.match.params.id === 'new',
+            isNewScenario: this.props.match.params.id === 'new',
             activeIndex: SCENARIO_TAB_INDEX
         };
         this.onTabChange = this.onTabChange.bind(this);
@@ -30,7 +30,7 @@ class Editor extends Component {
         const scenarioId = this.props.match.params.id;
         let endpoint, method;
 
-        if (this.state.isNewPost) {
+        if (this.state.isNewScenario) {
             endpoint = '/api/scenarios';
             method = 'PUT';
         } else {
@@ -50,7 +50,7 @@ class Editor extends Component {
     }
 
     getPostSubmitCallback() {
-        if (this.state.isNewPost) {
+        if (this.state.isNewScenario) {
             return scenarioData => {
                 this.props.history.push(`/editor/${scenarioData.id}`);
                 this.setState({ activeIndex: SLIDE_TAB_INDEX });

--- a/client/components/ScenarioEditor/index.jsx
+++ b/client/components/ScenarioEditor/index.jsx
@@ -66,7 +66,6 @@ class ScenarioEditor extends Component {
                 break;
             case 201:
                 this.setState({ saving: false, saveMessage: 'Saved!' });
-                this.props.history.push(`/editor/${saveResponse.scenario.id}`);
                 break;
             default:
                 if (saveResponse.error) {
@@ -76,6 +75,10 @@ class ScenarioEditor extends Component {
                     });
                 }
                 break;
+        }
+
+        if (this.props.postSubmitCB) {
+            this.props.postSubmitCB(saveResponse.scenario);
         }
     }
 
@@ -140,12 +143,10 @@ const mapDispatchToProps = {
 };
 
 ScenarioEditor.propTypes = {
-    history: PropTypes.shape({
-        push: PropTypes.func.isRequired
-    }).isRequired,
     scenarioId: PropTypes.node.isRequired,
     setScenario: PropTypes.func.isRequired,
     submitCB: PropTypes.func.isRequired,
+    postSubmitCB: PropTypes.func,
     title: PropTypes.string,
     description: PropTypes.string
 };


### PR DESCRIPTION
@gnarf @rwaldron this covers Rachel's user testing feedback that it would be nice to see the slides tab after saving a scenario. I made this the case only for new scenarios, but let me know if it should always happen.

Proposed changes:
- Add post submit callback
- Redirect to edit scenario in editor and focus slides tab when saving a scenario for the first time
- Add onTabChange event to set the active tab if a user clicks on a different one