### PR TITLE
Editor message component

### DIFF
--- a/client/components/Editor/Slides.jsx
+++ b/client/components/Editor/Slides.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Grid, Card, Dropdown, Button } from 'semantic-ui-react';
+import { Container, Grid, Card, Dropdown, Button } from 'semantic-ui-react';
 import * as Components from '@components/Slide/Components';
 import SlideEditor from '@components/Slide/Editor';
 import './Slides.css';
@@ -127,56 +127,63 @@ class Slides extends React.Component {
         const { loading, slides, currentSlideIndex } = this.state;
         if (loading) return this.renderLoading();
         return (
-            <Grid>
-                <Grid.Column width={3}>
-                    <Grid.Row>
-                        <Dropdown
-                            selection
-                            placeholder="Add +"
-                            options={dropDownValues}
-                            onChange={onChangeAddSlide}
-                        />
-                    </Grid.Row>
-                    {slides.map((slide, index) => (
-                        <Grid.Row key={slide.id}>
-                            <Card
-                                onClick={() =>
-                                    this.setState({ currentSlideIndex: index })
-                                }
-                            >
-                                <Card.Header>{slide.title}</Card.Header>
-                                <Card.Content>
-                                    {slide.components.map(({ type }, index) => {
-                                        const {
-                                            Card = () => <b>{type}</b>
-                                        } = Components[type];
-                                        return <Card key={index} />;
-                                    })}
-                                    <p>
-                                        <Button
-                                            icon="trash alternate outline"
-                                            aria-label="Delete Slide"
-                                            className="Slides-delete-button"
-                                            onClick={() =>
-                                                this.deleteSlide(index)
-                                            }
-                                        />
-                                    </p>
-                                </Card.Content>
-                            </Card>
+            <Container fluid className="tm__editor-tab">
+                <h2>Teacher Moment Slides</h2>
+                <Grid>
+                    <Grid.Column width={3}>
+                        <Grid.Row>
+                            <Dropdown
+                                selection
+                                placeholder="Add +"
+                                options={dropDownValues}
+                                onChange={onChangeAddSlide}
+                            />
                         </Grid.Row>
-                    ))}
-                </Grid.Column>
-                <Grid.Column width={8}>
-                    {slides[currentSlideIndex] && (
-                        <SlideEditor
-                            key={currentSlideIndex}
-                            {...slides[currentSlideIndex]}
-                            onChange={onChangeSlide}
-                        />
-                    )}
-                </Grid.Column>
-            </Grid>
+                        {slides.map((slide, index) => (
+                            <Grid.Row key={slide.id}>
+                                <Card
+                                    onClick={() =>
+                                        this.setState({
+                                            currentSlideIndex: index
+                                        })
+                                    }
+                                >
+                                    <Card.Header>{slide.title}</Card.Header>
+                                    <Card.Content>
+                                        {slide.components.map(
+                                            ({ type }, index) => {
+                                                const {
+                                                    Card = () => <b>{type}</b>
+                                                } = Components[type];
+                                                return <Card key={index} />;
+                                            }
+                                        )}
+                                        <p>
+                                            <Button
+                                                icon="trash alternate outline"
+                                                aria-label="Delete Slide"
+                                                className="Slides-delete-button"
+                                                onClick={() =>
+                                                    this.deleteSlide(index)
+                                                }
+                                            />
+                                        </p>
+                                    </Card.Content>
+                                </Card>
+                            </Grid.Row>
+                        ))}
+                    </Grid.Column>
+                    <Grid.Column width={8}>
+                        {slides[currentSlideIndex] && (
+                            <SlideEditor
+                                key={currentSlideIndex}
+                                {...slides[currentSlideIndex]}
+                                onChange={onChangeSlide}
+                            />
+                        )}
+                    </Grid.Column>
+                </Grid>
+            </Container>
         );
     }
 }

--- a/client/components/Editor/Slides.jsx
+++ b/client/components/Editor/Slides.jsx
@@ -60,6 +60,7 @@ class Slides extends React.Component {
         const { scenarioId } = this.props;
         const { slides, currentSlideIndex } = this.state;
         const slide = slides[currentSlideIndex];
+        this.props.updateEditorMessage('');
         clearTimeout(this.debounceSlideUpdate[slide.id]);
         this.debounceSlideUpdate[slide.id] = setTimeout(async () => {
             const newSlide = {
@@ -81,6 +82,7 @@ class Slides extends React.Component {
                 currSlide.id === savedSlide.id ? savedSlide : currSlide
             );
             this.setState({ slides });
+            this.props.updateEditorMessage('Slide saved');
         }, 250);
     }
 
@@ -96,9 +98,11 @@ class Slides extends React.Component {
         await result.json();
         const slides = this.state.slides.filter(({ id }) => id !== slide.id);
         this.setState({ slides, currentSlideIndex: -1 });
+        this.props.updateEditorMessage('Slide deleted');
     }
 
     async onChangeAddSlide(event, data) {
+        this.props.updateEditorMessage('');
         const { scenarioId } = this.props;
         const newSlide = { title: data.value, components: [] };
         const res = await fetch(`/api/scenarios/${scenarioId}/slides`, {
@@ -189,6 +193,7 @@ class Slides extends React.Component {
 }
 
 Slides.propTypes = {
-    scenarioId: PropTypes.string
+    scenarioId: PropTypes.string,
+    updateEditorMessage: PropTypes.func.isRequired
 };
 export default Slides;

--- a/client/components/Editor/editor.css
+++ b/client/components/Editor/editor.css
@@ -6,3 +6,8 @@
     margin-top: 1rem;
     font-size: 1.1rem;
 }
+
+.tm__editor-tab {
+    margin: 1rem;
+    padding: 1rem;
+}

--- a/client/components/Editor/index.jsx
+++ b/client/components/Editor/index.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Menu, Segment, Tab } from 'semantic-ui-react';
+import { Menu } from 'semantic-ui-react';
 import PropTypes from 'prop-types';
 
 import ScenarioEditor from '@components/ScenarioEditor';
@@ -7,7 +7,7 @@ import Slides from './Slides';
 
 import './editor.css';
 
-const EditorMessage = message => {
+const EditorMessage = ({ message }) => {
     return <div>{message}</div>;
 };
 
@@ -15,6 +15,11 @@ class Editor extends Component {
     constructor(props) {
         super(props);
 
+        this.onClick = this.onClick.bind(this);
+        this.getSubmitCallback = this.getSubmitCallback.bind(this);
+        this.getPostSubmitCallback = this.getPostSubmitCallback.bind(this);
+        this.getTab = this.getTab.bind(this);
+        this.updateEditorMessage = this.updateEditorMessage.bind(this);
         this.state = {
             activeTab: 'moment',
             editorMessage: '',
@@ -24,19 +29,18 @@ class Editor extends Component {
             }
         };
 
-        this.onClick = this.onClick.bind(this);
-        this.getSubmitCallback = this.getSubmitCallback.bind(this);
-        this.getPostSubmitCallback = this.getPostSubmitCallback.bind(this);
-        this.getTab = this.getTab.bind(this);
-
         if (this.props.match.params.id != 'new') {
-            const tabsObj = { ...this.state.tabs, slides: this.getTab('slides') };
+            const tabsObj = {
+                ...this.state.tabs,
+                slides: this.getTab('slides')
+            };
             this.state.tabs = tabsObj;
         }
     }
 
     onClick(e, { name }) {
         this.setState({ activeTab: name });
+        this.updateEditorMessage('');
     }
 
     getTab(name) {
@@ -47,6 +51,7 @@ class Editor extends Component {
                         scenarioId={this.props.match.params.id}
                         submitCB={this.getSubmitCallback()}
                         postSubmitCB={this.getPostSubmitCallback()}
+                        updateEditorMessage={this.updateEditorMessage}
                     />
                 );
             case 'slides':
@@ -54,6 +59,7 @@ class Editor extends Component {
                     <Slides
                         scenarioId={this.props.match.params.id}
                         className="active"
+                        updateEditorMessage={this.updateEditorMessage}
                     />
                 );
             default:
@@ -104,12 +110,16 @@ class Editor extends Component {
         return null;
     }
 
+    updateEditorMessage(message) {
+        this.setState({ editorMessage: message });
+    }
+
     render() {
         return (
             <div>
                 <Menu attached="top" tabular>
                     <Menu.Item
-                        name='moment'
+                        name="moment"
                         active={this.state.activeTab === 'moment'}
                         onClick={this.onClick}
                     />
@@ -122,7 +132,7 @@ class Editor extends Component {
                     )}
                     <Menu.Menu position="right">
                         <Menu.Item>
-                            <div>{this.state.editorMessage}</div>
+                            <EditorMessage message={this.state.editorMessage} />
                         </Menu.Item>
                     </Menu.Menu>
                 </Menu>
@@ -132,6 +142,10 @@ class Editor extends Component {
         );
     }
 }
+
+EditorMessage.propTypes = {
+    message: PropTypes.string
+};
 
 Editor.propTypes = {
     history: PropTypes.shape({

--- a/client/components/ScenarioEditor/index.jsx
+++ b/client/components/ScenarioEditor/index.jsx
@@ -84,7 +84,7 @@ class ScenarioEditor extends Component {
 
     render() {
         return (
-            <Container fluid className="tm__scenario-editor">
+            <Container fluid className="tm__editor-tab">
                 <h2>Teacher Moment Details</h2>
                 <Form size={'big'}>
                     <Form.Input

--- a/client/components/ScenarioEditor/index.jsx
+++ b/client/components/ScenarioEditor/index.jsx
@@ -10,8 +10,7 @@ class ScenarioEditor extends Component {
     constructor(props) {
         super(props);
         this.state = {
-            saving: false,
-            saveMessage: ''
+            saving: false
         };
 
         this.getScenarioData = this.getScenarioData.bind(this);
@@ -39,18 +38,15 @@ class ScenarioEditor extends Component {
     }
 
     handleChange(event) {
-        this.setState({
-            saveMessage: ''
-        });
+        this.props.updateEditorMessage('');
         this.props.setScenario({ [event.target.name]: event.target.value });
     }
 
     async handleSubmit() {
         if (!this.props.title || !this.props.description) {
-            this.setState({
-                saveMessage:
-                    'A title and description are required for Teacher Moments'
-            });
+            this.props.updateEditorMessage(
+                'A title and description are required for Teacher Moments'
+            );
             return;
         }
         this.setState({ saving: true });
@@ -62,17 +58,17 @@ class ScenarioEditor extends Component {
 
         switch (saveResponse.status) {
             case 200:
-                this.setState({ saving: false, saveMessage: 'Saved!' });
+                this.setState({ saving: false });
+                this.props.updateEditorMessage('Teacher Moment saved');
                 break;
             case 201:
-                this.setState({ saving: false, saveMessage: 'Saved!' });
+                this.setState({ saving: false });
+                this.props.updateEditorMessage('Teacher Moment created');
                 break;
             default:
                 if (saveResponse.error) {
-                    this.setState({
-                        saving: false,
-                        saveMessage: saveResponse.message
-                    });
+                    this.setState({ saving: false });
+                    this.props.updateEditorMessage(saveResponse.message);
                 }
                 break;
         }
@@ -147,6 +143,7 @@ ScenarioEditor.propTypes = {
     setScenario: PropTypes.func.isRequired,
     submitCB: PropTypes.func.isRequired,
     postSubmitCB: PropTypes.func,
+    updateEditorMessage: PropTypes.func.isRequired,
     title: PropTypes.string,
     description: PropTypes.string
 };

--- a/client/components/ScenarioEditor/scenarioEditor.css
+++ b/client/components/ScenarioEditor/scenarioEditor.css
@@ -1,8 +1,3 @@
-.tm__scenario-editor {
-    margin: 1rem;
-    padding: 1rem;
-}
-
 .tm__scenario-save {
     margin: 1rem 0;
 }


### PR DESCRIPTION
@gnarf @rwaldron here is my PR for adding a re-usable component for displaying messages in the editor. It ended up being a little more complicated than I had hoped because I needed to switch to Semantic UI's `Menu` component in order to have a right-aligned string next to the tabs. So some of these changes are re-creating the builtin display logic we used to get for free with the `Tab` component. 

Another note, I switched to using `this.state.scenarioId` or `this.props.match.params.id`  instead of `this.state.isNewScenario` because state didn't always seem to be mounted when I needed it.

Let me know what you think and if you have any questions!