### PR TITLE
Clear cached new scenario values on first save

### DIFF
--- a/client/components/Editor/index.jsx
+++ b/client/components/Editor/index.jsx
@@ -126,11 +126,14 @@ class Editor extends Component {
                     scenarioId: scenarioData.id
                 });
 
-                if (!this.state.tabs.slides) {
-                    const tabs = this.state.tabs;
-                    tabs.slides = this.getTab('slides');
-                    this.setState({ tabs });
-                }
+                // Clear cached new scenario values from tabs
+                const tabs = Object.assign({}, this.state.tabs, {
+                    moment: this.getTab('moment'),
+                    slides: this.getTab('slides'),
+                    preview: this.getTab('preview')
+                });
+
+                this.setState({ tabs });
             };
         }
 


### PR DESCRIPTION
@rwaldron @evmiguel @gnarf I thought I had merged this fix in earlier, but then realized it was missing even from the git history 😅 

In any case, this fixes an issue where if you first create a moment and then try to go back to the "Moment" tab, it will be empty and try to save a new moment on submit. 