### PR TITLE
Fullscreen slides

### DIFF
--- a/client/components/Scenario/ContentSlide.jsx
+++ b/client/components/Scenario/ContentSlide.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Card } from 'semantic-ui-react';
+
+import SlideComponentsList from '@components/SlideComponentsList';
+
+const ContentSlide = (slide, cardClass, SlideButton) => {
+    return (
+        <Card id={slide.id} key={slide.id} centered className={cardClass}>
+            <Card.Header as="h3" key={`header${slide.id}`}>
+                {slide.title}
+            </Card.Header>
+            <Card.Content key={`content${slide.id}`}>
+                <SlideComponentsList components={slide.components} />
+                {SlideButton}
+            </Card.Content>
+        </Card>
+    );
+};
+
+export default ContentSlide;

--- a/client/components/Scenario/DescriptionSlide.jsx
+++ b/client/components/Scenario/DescriptionSlide.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Card } from 'semantic-ui-react';
+
+const DescriptionSlide = ({ title, description }, cardClass, SlideButton) => {
+    return (
+        <Card id="meta" key="meta" centered className={cardClass}>
+            <Card.Header as="h2">{title}</Card.Header>
+            <Card.Content>
+                {description}
+                {SlideButton}
+            </Card.Content>
+        </Card>
+    );
+};
+
+DescriptionSlide.propTypes = {
+    title: PropTypes.string,
+    description: PropTypes.string
+};
+
+export default DescriptionSlide;

--- a/client/components/Scenario/Scenario.css
+++ b/client/components/Scenario/Scenario.css
@@ -1,0 +1,21 @@
+.ui.card.scenario__card {
+    width: 80%;
+    max-width: 500px;
+}
+
+.ui.card.scenario__card--run {
+    width: 80vw;
+    height: 85vh;
+    max-width: 500px;
+    margin-top: 2vh;
+}
+
+.scenario__card .scenario__card--button {
+    padding: 5% 40% 2% 40%;
+}
+
+.ui.card.scenario__card--run .scenario__card--button {
+    position: absolute;
+    bottom: 0;
+    padding: 10% 40%;
+}

--- a/client/components/Scenario/index.jsx
+++ b/client/components/Scenario/index.jsx
@@ -1,10 +1,12 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { Grid, Card } from 'semantic-ui-react';
+import { Button, Grid } from 'semantic-ui-react';
 
-import SlideComponentsList from '@components/SlideComponentsList';
+import DescriptionSlide from './DescriptionSlide';
+import ContentSlide from './ContentSlide';
 import { setScenario, setSlides } from '@client/actions';
+import './Scenario.css';
 
 class Scenario extends Component {
     constructor(props) {
@@ -13,86 +15,144 @@ class Scenario extends Component {
         // Check for data from route or props
         this.state = Object.assign(
             {},
-            { scenarioId: this.props.scenarioId },
+            {
+                scenarioId: this.props.scenarioId,
+                activeSlideIndex: 0
+            },
             this.props.location ? this.props.location.state : null,
             this.props.match ? this.props.match.params : null
         );
 
-        this.getScenarioData = this.getScenarioData.bind(this);
+        this.isScenarioRun = this.isScenarioRun.bind(this);
+        this.getOnClickHandler = this.getOnClickHandler.bind(this);
+        this.getSlideButton = this.getSlideButton.bind(this);
+        this.getScenarioMetaData = this.getScenarioMetaData.bind(this);
+        this.getScenarioContent = this.getScenarioContent.bind(this);
         this.getScenarioSlides = this.getScenarioSlides.bind(this);
 
-        // Get data that hasn't been passed by the router
-        this.getScenarioData();
         this.getScenarioSlides();
     }
 
-    async getScenarioData() {
+    isScenarioRun() {
+        return location.pathname.includes('/moment/');
+    }
+
+    getSlideButton(type) {
+        const onClick = this.getOnClickHandler(type);
+
+        return (
+            <div className="scenario__card--button">
+                <Button basic color="black" onClick={onClick}>
+                    {type[0].toUpperCase() + type.slice(1)}
+                </Button>
+            </div>
+        );
+    }
+
+    getOnClickHandler(type) {
+        if (!this.isScenarioRun()) {
+            return null;
+        }
+
+        switch (type) {
+            case 'next':
+                return () => {
+                    let activeSlideIndex = this.state.activeSlideIndex;
+                    activeSlideIndex++;
+                    this.setState({ activeSlideIndex });
+                };
+            case 'finish':
+                return () => {
+                    this.props.history.push('/');
+                };
+            default:
+                return null;
+        }
+    }
+
+    async getScenarioMetaData() {
+        let title, description;
+
         if (this.state.title && this.state.description) {
             this.props.setScenario({
                 title: this.state.title,
                 description: this.state.description
             });
-            return;
+            title = this.state.title;
+            description = this.state.description;
+        } else {
+            const scenarioResponse = await (await fetch(
+                `/api/scenarios/${this.state.scenarioId}`
+            )).json();
+            const scenario = scenarioResponse.scenario;
+
+            if (scenarioResponse.status === 200) {
+                this.props.setScenario({
+                    title: scenario.title,
+                    description: scenario.description
+                });
+                title = scenario.title;
+                description = scenario.description;
+            }
         }
 
-        const scenarioResponse = await (await fetch(
-            `/api/scenarios/${this.state.scenarioId}`
-        )).json();
-        const scenario = scenarioResponse.scenario;
-
-        if (scenarioResponse.status === 200) {
-            this.props.setScenario({
-                title: scenario.title,
-                description: scenario.description
-            });
-        }
+        return { title, description };
     }
 
-    async getScenarioSlides() {
+    async getScenarioContent() {
         if (this.state.scenarioId) {
             const res = await fetch(
                 `/api/scenarios/${this.state.scenarioId}/slides`
             );
             const { slides } = await res.json();
-            this.props.setSlides({ slides });
-        } else {
-            this.props.setSlides({ slides: null });
+            return slides;
         }
+        return null;
+    }
+
+    async getScenarioSlides() {
+        const cardClass = this.isScenarioRun()
+            ? 'scenario__card--run'
+            : 'scenario__card';
+        const metaData = await this.getScenarioMetaData();
+        const contentData = await this.getScenarioContent();
+        // Check if the description slide is the last one
+        const descriptionSlideButton = !contentData.length
+            ? this.getSlideButton('finish')
+            : this.getSlideButton('next');
+        const descriptionSlide = DescriptionSlide(
+            metaData,
+            cardClass,
+            descriptionSlideButton
+        );
+        const scenarioSlides = [];
+
+        scenarioSlides.push(descriptionSlide);
+        contentData.map((slide, index) => {
+            const isLastSlide = index === contentData.length - 1;
+            const slideButton = isLastSlide
+                ? this.getSlideButton('finish')
+                : this.getSlideButton('next');
+            const displaySlide = ContentSlide(slide, cardClass, slideButton);
+            scenarioSlides.push(displaySlide);
+        });
+
+        this.props.setSlides({
+            slides: [...(scenarioSlides || [])]
+        });
     }
 
     render() {
-        const { title, description, slides } = this.props;
-        return (
+        const { slides } = this.props;
+        return this.isScenarioRun() ? (
             <Grid columns={1}>
                 <Grid.Column>
-                    <Grid.Row key="meta">
-                        <Card className="scenario__card">
-                            <Card.Header as="h2">{title}</Card.Header>
-                            <Card.Content>{description}</Card.Content>
-                        </Card>
-                    </Grid.Row>
-
-                    {slides &&
-                        slides.map((slide, index) => {
-                            return (
-                                <Grid.Row key={index}>
-                                    <Card className="scenario__card">
-                                        <Card.Header
-                                            as="h3"
-                                            key={`header${index}`}
-                                        >
-                                            {slide.title}
-                                        </Card.Header>
-                                        <Card.Content key={`content${index}`}>
-                                            <SlideComponentsList
-                                                components={slide.components}
-                                            />
-                                        </Card.Content>
-                                    </Card>
-                                </Grid.Row>
-                            );
-                        })}
+                    {slides && slides[this.state.activeSlideIndex]}
                 </Grid.Column>
+            </Grid>
+        ) : (
+            <Grid columns={1}>
+                <Grid.Column>{slides}</Grid.Column>
             </Grid>
         );
     }
@@ -116,6 +176,9 @@ Scenario.propTypes = {
         params: PropTypes.shape({
             id: PropTypes.node
         }).isRequired
+    }),
+    history: PropTypes.shape({
+        push: PropTypes.func.isRequired
     }),
     scenarioId: PropTypes.node,
     setScenario: PropTypes.func.isRequired,

--- a/client/components/SlideComponentsList/SlideComponentsList.css
+++ b/client/components/SlideComponentsList/SlideComponentsList.css
@@ -1,5 +1,0 @@
-.ui.card.scenario__card {
-    width: 80%;
-    max-width: 500px;
-    margin: 1.5rem auto;
-}

--- a/client/components/SlideComponentsList/index.jsx
+++ b/client/components/SlideComponentsList/index.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import * as Components from '@components/Slide/Components';
-import './SlideComponentsList.css';
 
 const SlideComponentsList = ({ asSVG = false, components }) => {
     const style = {


### PR DESCRIPTION
We got full screen slides!!

<img width="822" alt="Screen Shot 2019-11-01 at 1 47 43 PM" src="https://user-images.githubusercontent.com/7991694/68055574-3712d180-fcae-11e9-83a4-b77a9600332d.png">


These changes:
- allow only one slide to be visible at a time in the frontend view of scenarios
- allows all slides to be visible in the editor preview
- advances slides on click in scenario run and not in preview