### PR TITLE
Add admin UI for editing user roles

### DIFF
--- a/client/actions/index.js
+++ b/client/actions/index.js
@@ -1,4 +1,4 @@
-import { LOG_IN, LOG_OUT, SET_SCENARIO, SET_SLIDES } from './types';
+import { LOG_IN, LOG_OUT, SET_SCENARIO, SET_SLIDES, SET_USERS } from './types';
 
 export const logIn = username => ({
     type: LOG_IN,
@@ -21,7 +21,12 @@ export const setScenario = scenarioData => ({
     payload: scenarioData
 });
 
-export const setSlides = scenarioData => ({
+export const setSlides = slidesData => ({
     type: SET_SLIDES,
-    payload: scenarioData
+    payload: slidesData
+});
+
+export const setUsers = userData => ({
+    type: SET_USERS,
+    payload: userData
 });

--- a/client/actions/types.js
+++ b/client/actions/types.js
@@ -2,3 +2,4 @@ export const LOG_IN = 'LOG_IN';
 export const LOG_OUT = 'LOG_OUT';
 export const SET_SCENARIO = 'SET_SCENARIO';
 export const SET_SLIDES = 'SET_SLIDES';
+export const SET_USERS = 'SET_USERS';

--- a/client/components/AccountAdmin/UserRows.jsx
+++ b/client/components/AccountAdmin/UserRows.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { Checkbox, Table } from 'semantic-ui-react';
+
+const USER_ROLES = Object.freeze({
+    super_admin: 'Super Admin',
+    admin: 'Admin',
+    researcher: 'Researcher',
+    facilitator: 'Facilitator',
+    participant: 'Participant'
+});
+
+const onCheckboxClick = async (event, { email, username, role, checked }) => {
+    const endpoint = checked ? '/api/roles/add' : '/api/roles/delete';
+    const body = JSON.stringify({
+        roles: [role],
+        email,
+        username
+    });
+    fetch(endpoint, {
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        method: 'POST',
+        body
+    });
+};
+
+const RoleCells = ({ username, email, roles }) => {
+    return Object.keys(USER_ROLES).map(dbValue => {
+        const checked = roles ? roles.includes(dbValue) : false;
+
+        return (
+            <Table.Cell key={dbValue}>
+                <Checkbox
+                    role={dbValue}
+                    username={username}
+                    email={email}
+                    defaultChecked={checked}
+                    onClick={onCheckboxClick}
+                />
+            </Table.Cell>
+        );
+    });
+};
+
+const UserRows = users => {
+    if (!users) return null;
+
+    return users.map(user => {
+        const roleCells = RoleCells(user);
+        return (
+            <Table.Row key={user.id}>
+                <Table.Cell>{user.username}</Table.Cell>
+                <Table.Cell>{user.email}</Table.Cell>
+                {roleCells}
+            </Table.Row>
+        );
+    });
+};
+
+export default UserRows;

--- a/client/components/AccountAdmin/index.jsx
+++ b/client/components/AccountAdmin/index.jsx
@@ -1,0 +1,76 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { Table } from 'semantic-ui-react';
+import PropTypes from 'prop-types';
+
+import UserRows from './UserRows';
+import { setUsers } from '@client/actions';
+
+class AccountAdmin extends Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            users: null
+        };
+
+        this.getUsers = this.getUsers.bind(this);
+
+        this.getUsers();
+    }
+
+    async getUsers() {
+        const usersResponse = await (await fetch('api/roles')).json();
+        let users = null;
+        if (usersResponse.status === 200) {
+            users = usersResponse.users;
+        }
+
+        this.props.setUsers({ users });
+    }
+
+    render() {
+        const { users } = this.props;
+        const usersDisplay = UserRows(users);
+
+        return (
+            <React.Fragment>
+                <h1>Account Admin</h1>
+                <Table celled>
+                    <Table.Header>
+                        <Table.Row>
+                            <Table.HeaderCell>Username</Table.HeaderCell>
+                            <Table.HeaderCell>Email</Table.HeaderCell>
+                            <Table.HeaderCell>Super Admin</Table.HeaderCell>
+                            <Table.HeaderCell>Admin</Table.HeaderCell>
+                            <Table.HeaderCell>Researcher</Table.HeaderCell>
+                            <Table.HeaderCell>Facilitator</Table.HeaderCell>
+                            <Table.HeaderCell>Participant</Table.HeaderCell>
+                        </Table.Row>
+                    </Table.Header>
+
+                    <Table.Body>{usersDisplay}</Table.Body>
+                </Table>
+            </React.Fragment>
+        );
+    }
+}
+
+AccountAdmin.propTypes = {
+    setUsers: PropTypes.func.isRequired,
+    users: PropTypes.array
+};
+
+function mapStateToProps(state) {
+    const { users } = state.admin;
+    return { users };
+}
+
+const mapDispatchToProps = {
+    setUsers
+};
+
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(AccountAdmin);

--- a/client/components/CreateAccount/index.jsx
+++ b/client/components/CreateAccount/index.jsx
@@ -151,7 +151,6 @@ CreateAccount.propTypes = {
         push: PropTypes.func.isRequired
     }).isRequired,
     logIn: PropTypes.func.isRequired,
-    logOut: PropTypes.func.isRequired,
     isLoggedIn: PropTypes.bool.isRequired,
     username: PropTypes.string
 };

--- a/client/reducers/admin.js
+++ b/client/reducers/admin.js
@@ -1,0 +1,17 @@
+import { SET_USERS } from '@client/actions/types';
+
+const initialState = {
+    users: null
+};
+
+export default function(state = initialState, action) {
+    switch (action.type) {
+        case SET_USERS:
+            return {
+                ...state,
+                users: action.payload.users
+            };
+        default:
+            return state;
+    }
+}

--- a/client/reducers/index.js
+++ b/client/reducers/index.js
@@ -2,5 +2,6 @@ import { combineReducers } from 'redux';
 
 import login from './login';
 import scenario from './scenario';
+import admin from './admin';
 
-export default combineReducers({ login, scenario });
+export default combineReducers({ login, scenario, admin });

--- a/client/routes/index.jsx
+++ b/client/routes/index.jsx
@@ -11,6 +11,7 @@ import ScenariosList from '@client/components/ScenariosList';
 import Scenario from '@client/components/Scenario';
 import Editor from '@client/components/Editor';
 import Facilitator from '@client/components/Facilitator';
+import AccountAdmin from '@client/components/AccountAdmin';
 import Login from '@client/components/Login';
 import CreateAccount from '@client/components/CreateAccount';
 
@@ -54,6 +55,9 @@ const GeneralRoutes = () => {
                         <Menu.Item>
                             <NavLink to="/facilitator">Facilitator</NavLink>
                         </Menu.Item>
+                        <Menu.Item>
+                            <NavLink to="/admin">Admin</NavLink>
+                        </Menu.Item>
                     </React.Fragment>
                 )}
                 <Menu.Item position="right">
@@ -71,6 +75,7 @@ const GeneralRoutes = () => {
             <Route path="/moment/:scenarioId" component={Scenario} />
             <Route path="/editor/:id" component={Editor} />
             <Route exact path="/facilitator" component={Facilitator} />
+            <Route exact path="/admin" component={AccountAdmin} />
             <Route exact path="/logout" component={Login} />
             <Route exact path="/login" component={Login} />
             <Route path="/login/new" component={CreateAccount} />

--- a/server/migrations/20191107192140-user-role-view.js
+++ b/server/migrations/20191107192140-user-role-view.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const sqlFile = require('./helpers/sql-file')(__filename);
+exports.up = function(db) {
+    return db.runSql(sqlFile.up);
+};
+exports.down = function(db) {
+    return db.runSql(sqlFile.down);
+};
+exports._meta = {
+    version: 1
+};

--- a/server/migrations/sql/20191107192140-user-role-view.sql
+++ b/server/migrations/sql/20191107192140-user-role-view.sql
@@ -1,0 +1,11 @@
+CREATE VIEW user_role_detail AS
+SELECT
+    users.id,
+    users.username,
+    users.email,
+    (SELECT ARRAY_AGG(role) AS roles from user_role WHERE user_role.user_id = users.id)
+FROM users;
+
+---
+
+DROP VIEW user_role_detail;

--- a/server/service/roles/db.js
+++ b/server/service/roles/db.js
@@ -10,9 +10,9 @@ exports.getUserById = async function getUserById(id) {
     });
 };
 
-exports.getAllUsers = async function getAllUsers() {
+exports.getAllUsersRoles = async function getAllUsersRoles() {
     return withClient(async client => {
-        const result = await client.query(sql`SELECT * FROM users`);
+        const result = await client.query(sql`SELECT * FROM user_role_detail`);
         return result.rows;
     });
 };

--- a/server/service/roles/index.js
+++ b/server/service/roles/index.js
@@ -6,14 +6,14 @@ const { requireUserRole, checkCanEditUserRoles } = require('./middleware');
 const rolesRouter = Router();
 
 const {
-    getAllUsers,
+    getAllUsersRoles,
     getUserRoles,
     addUserRoles,
     deleteUserRoles,
     setUserRoles
 } = require('./endpoints');
 
-rolesRouter.get('/', [requireUserRole('admin'), getAllUsers]);
+rolesRouter.get('/', [requireUserRole('admin'), getAllUsersRoles]);
 
 rolesRouter.get('/:user_id', [requireUserRole('admin'), getUserRoles]);
 
@@ -23,14 +23,14 @@ rolesRouter.put('/:user_id', [
     setUserRoles
 ]);
 
-rolesRouter.post('/:user_id/add', [
-    checkCanEditUserRoles(req => req.params.user_id),
+rolesRouter.post('/add', [
+    checkCanEditUserRoles(req => req.session.user.id),
     validateRequestBody,
     addUserRoles
 ]);
 
-rolesRouter.post('/:user_id/delete', [
-    checkCanEditUserRoles(req => req.params.user_id),
+rolesRouter.post('/delete', [
+    checkCanEditUserRoles(req => req.session.user.id),
     validateRequestBody,
     deleteUserRoles
 ]);


### PR DESCRIPTION
@evmiguel @gnarf @rwaldron here is a PR for adding an admin UI for editing user roles. 

My proposed changes:
- Add account admin components and related Redux action, reducer
- Fixes login form bug where username is required (it shouldn't be, right? Like if someone just wants to use their email address? Let me know if I have that wrong)
- Adds a SQL view for getting all users and aggregating their roles (currently each user's role is a separate row in `user_role`
- Adjust server roles routes to use the req.body and req.session for wherever we need user information and not route params.

<img width="984" alt="Screen Shot 2019-11-08 at 5 38 31 PM" src="https://user-images.githubusercontent.com/7991694/68515399-cab84500-024e-11ea-8ad6-170195486f38.png">

Let me know what you think! Currently it auto saves with no messaging, which I know users didn't love before. However I'm wondering if TM admins would be more comfortable with auto-saving. 
