### PR TITLE
Add copy button, logic, endpoint for saving multiple slides

### DIFF
--- a/client/components/ScenarioEditor/index.jsx
+++ b/client/components/ScenarioEditor/index.jsx
@@ -21,8 +21,6 @@ class ScenarioEditor extends Component {
             categories: []
         };
 
-        this.fetchScenario = this.fetchScenario.bind(this);
-
         this.onChange = this.onChange.bind(this);
         this.onConsentChange = this.onConsentChange.bind(this);
         this.onSubmit = this.onSubmit.bind(this);
@@ -34,8 +32,6 @@ class ScenarioEditor extends Component {
                 categories: [],
                 status: 1
             });
-        } else {
-            this.fetchScenario();
         }
     }
 
@@ -69,30 +65,6 @@ class ScenarioEditor extends Component {
                     id,
                     prose
                 }
-            });
-        }
-    }
-
-    async fetchScenario() {
-        const { scenario, status } = await (await fetch(
-            `/api/scenarios/${this.props.scenarioId}`
-        )).json();
-
-        if (status === 200) {
-            const {
-                title,
-                description,
-                categories,
-                consent,
-                status
-            } = scenario;
-
-            this.props.setScenario({
-                title,
-                description,
-                categories,
-                consent,
-                status
             });
         }
     }

--- a/client/components/ScenariosList/ScenariosList.css
+++ b/client/components/ScenariosList/ScenariosList.css
@@ -1,20 +1,7 @@
-.tm__scenario-entry {
-    border-style: solid;
-    border-width: 1px;
-    border-color: #888888;
-    margin-right: 1rem;
-    margin-bottom: 1rem;
+.scenario__entry--edit-buttons {
+    width: 100%;
 }
 
-.tm__scenario-entry:hover {
-    background-color: #f5f5f5;
-}
-
-.tm__scenario-entry:active {
-    transform: translate(1px, 1px);
-}
-
-.tm__scenario-desc {
-    height: 150px;
-    overflow-y: auto;
+.ui.basic.button.scenario__entry--button:hover {
+    background-color: #cacbcd !important;
 }

--- a/client/components/ScenariosList/index.jsx
+++ b/client/components/ScenariosList/index.jsx
@@ -26,26 +26,41 @@ const ScenarioEntries = ({ scenarioData, isLoggedIn }) => {
                             basic
                             fluid
                             color="black"
-                            push="true"
                             as={Link}
-                            to={{ pathname: `/editor/${id}` }}
+                            to={{ pathname: `/run/${id}` }}
+                            className="scenario__entry--button"
                         >
-                            Edit
+                            Run
                         </Button>
                     </Card.Content>
                 )}
                 {isLoggedIn && (
                     <Card.Content extra>
-                        <Button
-                            basic
-                            fluid
-                            color="black"
-                            push="true"
-                            as={Link}
-                            to={{ pathname: `/run/${id}` }}
-                        >
-                            Run
-                        </Button>
+                        <Button.Group className="scenario__entry--edit-buttons">
+                            <Button
+                                basic
+                                color="black"
+                                className="scenario__entry--button"
+                                as={Link}
+                                to={{ pathname: `/editor/${id}` }}
+                            >
+                                Edit
+                            </Button>
+                            <Button
+                                basic
+                                color="black"
+                                className="scenario__entry--button"
+                                as={Link}
+                                to={{
+                                    pathname: `/editor/copy`,
+                                    state: {
+                                        scenarioCopyId: id
+                                    }
+                                }}
+                            >
+                                Copy
+                            </Button>
+                        </Button.Group>
                     </Card.Content>
                 )}
             </Card>
@@ -69,6 +84,7 @@ class ScenariosList extends Component {
 
     async getScenarios() {
         const scenariosResponse = await (await fetch('api/scenarios')).json();
+
         if (scenariosResponse.status === 200) {
             this.setState({ scenarioData: scenariosResponse.scenarios });
         }

--- a/client/reducers/scenario.js
+++ b/client/reducers/scenario.js
@@ -3,7 +3,7 @@ import { SET_SCENARIO, SET_SLIDES } from '@client/actions/types';
 const initialState = {
     title: '',
     description: '',
-    slides: null,
+    slides: [],
     status: 1
 };
 

--- a/server/service/scenarios/index.js
+++ b/server/service/scenarios/index.js
@@ -9,7 +9,8 @@ const {
     getAllScenarios,
     addScenario,
     setScenario,
-    deleteScenario
+    deleteScenario,
+    copyScenario
 } = require('./endpoints.js');
 
 scenariosRouter.get('/', getAllScenarios);
@@ -22,6 +23,8 @@ scenariosRouter.post('/:scenario_id', [
     validateRequestBody,
     setScenario
 ]);
+
+scenariosRouter.post('/:scenario_id/copy', [lookupScenario(), copyScenario]);
 
 scenariosRouter.delete('/:scenario_id', [lookupScenario(), deleteScenario]);
 

--- a/server/service/scenarios/slides/db.js
+++ b/server/service/scenarios/slides/db.js
@@ -24,6 +24,17 @@ exports.updateSlide = async (id, data) => {
     return result.rows[0];
 };
 
+exports.setAllSlides = async (scenario_id, slides) => {
+    const results = await query(sql`
+INSERT INTO slide (scenario_id, title, components)
+    SELECT ${scenario_id} as scenario_id, s.title, s.components FROM
+    jsonb_array_elements(${slides}) AS t(slide),
+    jsonb_to_record(t.slide) AS s (id int, title text, components jsonb)
+    ON CONFLICT DO NOTHING;
+    `);
+    return { addedCount: results.rowCount };
+};
+
 exports.deleteSlide = async ({ scenario_id, id }) => {
     const result = await query(
         sql`DELETE FROM slide WHERE id=${id} and scenario_id=${scenario_id}`

--- a/server/service/scenarios/slides/endpoints.js
+++ b/server/service/scenarios/slides/endpoints.js
@@ -43,6 +43,15 @@ exports.updateSlide = asyncMiddleware(async (req, res) => {
     });
 });
 
+exports.setAllSlides = asyncMiddleware(async (req, res) => {
+    const { id: scenario_id } = reqScenario(req);
+    const { slides } = req.body;
+    res.json({
+        slides: await db.setAllSlides(scenario_id, slides),
+        status: 200
+    });
+});
+
 exports.deleteSlide = asyncMiddleware(async (req, res) => {
     // TODO: ensure slide id is part of scenario / author permissions / etc
     const { id: scenario_id } = reqScenario(req);

--- a/server/service/scenarios/slides/index.js
+++ b/server/service/scenarios/slides/index.js
@@ -7,10 +7,12 @@ const {
     addSlide,
     orderSlides,
     updateSlide,
+    setAllSlides,
     deleteSlide
 } = require('./endpoints');
 
 slides.get('/', getSlides);
+slides.post('/', [validateRequestBody, setAllSlides]);
 slides.put('/', [validateRequestBody, addSlide]);
 slides.post('/order', [validateRequestBody, orderSlides]);
 slides.post('/:slide_id', [validateRequestBody, updateSlide]);


### PR DESCRIPTION
@evmiguel @rwaldron here is my PR for adding forking functionality, let me know what you think of it! My proposed changes:

- Add "copy" button to the UI and pass some of the original scenario's data to the copy via `location.state`
- A `copyScenario` function that creates a new scenario with this passed data, gets the original slides and saves that slides data to the new scenario as well
- Add an endpoint for bulk saving slides
- Small amount of refactoring