### PR TITLE
ScenarioEditor: only auto save after the scenario has been created by the user

### DIFF
--- a/client/components/ScenarioEditor/index.jsx
+++ b/client/components/ScenarioEditor/index.jsx
@@ -47,7 +47,12 @@ class ScenarioEditor extends Component {
     onChange(event, { name, value }) {
         this.props.updateEditorMessage('');
         this.props.setScenario({ [name]: value });
-        this.onSubmit();
+
+        // Only auto-save after initial
+        // save of new scenario
+        if (this.props.scenarioId !== 'new') {
+            this.onSubmit();
+        }
     }
 
     onConsentChange(event, { value }) {


### PR DESCRIPTION
This fixes the very broken "Create A Moment" view