### PR TITLE
Add mobile menu and fix some mobile stylings

### DIFF
--- a/client/components/ScenariosList/ScenariosList.css
+++ b/client/components/ScenariosList/ScenariosList.css
@@ -5,3 +5,7 @@
 .ui.basic.button.scenario__entry--button:hover {
     background-color: #cacbcd !important;
 }
+
+.ui.card.scenario__entry {
+    margin: 1rem auto;
+}

--- a/client/components/ScenariosList/index.jsx
+++ b/client/components/ScenariosList/index.jsx
@@ -15,7 +15,7 @@ const ScenarioEntries = ({ scenarioData, isLoggedIn }) => {
     // only filter out scenario if there is a path
     return scenarioData.map(({ id, title, description }) => {
         return (
-            <Card key={id}>
+            <Card className="scenario__entry" key={id}>
                 <Card.Content>
                     <Card.Header>{title}</Card.Header>
                     <Card.Description>{description}</Card.Description>

--- a/client/routes/Nav.css
+++ b/client/routes/Nav.css
@@ -1,0 +1,11 @@
+@media not all and (max-device-width: 767px) {
+    .ui.fluid.button.nav__mobile {
+        display: none;
+    }
+}
+
+@media not all and (min-width: 767px) {
+    .ui.fluid.button.nav__mobile {
+        display: block;
+    }
+}

--- a/client/routes/Navigation.jsx
+++ b/client/routes/Navigation.jsx
@@ -1,0 +1,82 @@
+import React, { useState } from 'react';
+import { NavLink } from 'react-router-dom';
+import { Button, Dropdown, Icon, Menu } from 'semantic-ui-react';
+
+import Session from '@client/util/session';
+const MOBILE_WIDTH = 767;
+
+Session.timeout();
+
+const Navigation = () => {
+    const [menuExpanded, setMenuExpanded] = useState(
+        !(window.innerWidth <= MOBILE_WIDTH)
+    );
+    window.onresize = () => {
+        if (window.innerWidth > MOBILE_WIDTH && !menuExpanded) {
+            // Make the menu appear if the user resizes the window to be wider
+            setMenuExpanded(true);
+        }
+    };
+
+    return (
+        <React.Fragment>
+            <Button
+                icon
+                fluid
+                labelPosition="left"
+                basic
+                className="nav__mobile"
+                id="nav__mobile--button"
+                onClick={() => setMenuExpanded(!menuExpanded)}
+                aria-controls="nav"
+            >
+                <Icon name="content" />
+                MENU
+            </Button>
+            {menuExpanded && (
+                <Menu id="nav" className="nav" stackable>
+                    <Menu.Item>
+                        <NavLink to="/">Teacher Moments</NavLink>
+                    </Menu.Item>
+
+                    <Menu.Menu>
+                        <Dropdown simple item text="Curated">
+                            <Dropdown.Menu>
+                                <Dropdown.Item>
+                                    <NavLink to="/official">Official</NavLink>
+                                </Dropdown.Item>
+                                <Dropdown.Item>
+                                    <NavLink to="/community">Community</NavLink>
+                                </Dropdown.Item>
+                            </Dropdown.Menu>
+                        </Dropdown>
+                    </Menu.Menu>
+                    {Session.isSessionActive() && (
+                        <React.Fragment>
+                            <Menu.Item>
+                                <NavLink exact to="/editor/new">
+                                    Create a Moment
+                                </NavLink>
+                            </Menu.Item>
+                            <Menu.Item>
+                                <NavLink to="/facilitator">Facilitator</NavLink>
+                            </Menu.Item>
+                            <Menu.Item>
+                                <NavLink to="/admin">Admin</NavLink>
+                            </Menu.Item>
+                        </React.Fragment>
+                    )}
+                    <Menu.Item position="right">
+                        {Session.isSessionActive() ? (
+                            <NavLink to="/logout">Log out</NavLink>
+                        ) : (
+                            <NavLink to="/login">Log in</NavLink>
+                        )}
+                    </Menu.Item>
+                </Menu>
+            )}
+        </React.Fragment>
+    );
+};
+
+export default Navigation;

--- a/client/routes/Routes.jsx
+++ b/client/routes/Routes.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Route, Switch } from 'react-router-dom';
+
+import ScenariosList from '@client/components/ScenariosList';
+import Editor from '@client/components/Editor';
+import Facilitator from '@client/components/Facilitator';
+import AccountAdmin from '@client/components/AccountAdmin';
+import Login from '@client/components/Login';
+import CreateAccount from '@client/components/CreateAccount';
+import Run from '@client/components/Run';
+
+// Special case component for solving new scenario routing issue.
+// Previously the route wouldn't update to the same Editor component.
+const NewScenario = props => {
+    return <Editor {...props} isNewScenario={true} />;
+};
+
+const Routes = () => {
+    return (
+        <Switch>
+            <Route exact path="/" component={ScenariosList} />
+            <Route exact path="/official" component={ScenariosList} />
+            <Route exact path="/community" component={ScenariosList} />
+            <Route path="/run/:scenarioId/:activeSlideIndex" component={Run} />
+            <Route path="/run/:scenarioId" component={Run} />
+            <Route exact path="/editor/new" component={NewScenario} />
+            <Route path="/editor/:id" component={Editor} />
+            <Route exact path="/facilitator" component={Facilitator} />
+            <Route exact path="/admin" component={AccountAdmin} />
+            <Route exact path="/logout" component={Login} />
+            <Route exact path="/login" component={Login} />
+            <Route path="/login/new" component={CreateAccount} />
+        </Switch>
+    );
+};
+
+export default Routes;

--- a/client/routes/index.jsx
+++ b/client/routes/index.jsx
@@ -1,92 +1,13 @@
 import React from 'react';
-import {
-    Route,
-    Switch,
-    NavLink,
-    BrowserRouter as Router
-} from 'react-router-dom';
-import { Dropdown, Menu } from 'semantic-ui-react';
+import { BrowserRouter as Router } from 'react-router-dom';
 
-import ScenariosList from '@client/components/ScenariosList';
-import Editor from '@client/components/Editor';
-import Facilitator from '@client/components/Facilitator';
-import AccountAdmin from '@client/components/AccountAdmin';
-import Login from '@client/components/Login';
-import CreateAccount from '@client/components/CreateAccount';
-import Run from '@client/components/Run';
+import Navigation from './Navigation';
+import Routes from './Routes';
+import './Nav.css';
 
 import Session from '@client/util/session';
 
 Session.timeout();
-
-// Special case component for solving new scenario routing issue.
-// Previously the route wouldn't update to the same Editor component.
-const NewScenario = props => {
-    return <Editor {...props} isNewScenario={true} />;
-};
-
-const Navigation = () => {
-    return (
-        <Menu className="nav">
-            <Menu.Item>
-                <NavLink to="/">Teacher Moments</NavLink>
-            </Menu.Item>
-
-            <Menu.Menu>
-                <Dropdown simple item text="Curated">
-                    <Dropdown.Menu>
-                        <Dropdown.Item>
-                            <NavLink to="/official">Official</NavLink>
-                        </Dropdown.Item>
-                        <Dropdown.Item>
-                            <NavLink to="/community">Community</NavLink>
-                        </Dropdown.Item>
-                    </Dropdown.Menu>
-                </Dropdown>
-            </Menu.Menu>
-            {Session.isSessionActive() && (
-                <React.Fragment>
-                    <Menu.Item>
-                        <NavLink exact to="/editor/new">
-                            Create a Moment
-                        </NavLink>
-                    </Menu.Item>
-                    <Menu.Item>
-                        <NavLink to="/facilitator">Facilitator</NavLink>
-                    </Menu.Item>
-                    <Menu.Item>
-                        <NavLink to="/admin">Admin</NavLink>
-                    </Menu.Item>
-                </React.Fragment>
-            )}
-            <Menu.Item position="right">
-                {Session.isSessionActive() ? (
-                    <NavLink to="/logout">Log out</NavLink>
-                ) : (
-                    <NavLink to="/login">Log in</NavLink>
-                )}
-            </Menu.Item>
-        </Menu>
-    );
-};
-const Routes = () => {
-    return (
-        <Switch>
-            <Route exact path="/" component={ScenariosList} />
-            <Route exact path="/official" component={ScenariosList} />
-            <Route exact path="/community" component={ScenariosList} />
-            <Route path="/run/:scenarioId/:activeSlideIndex" component={Run} />
-            <Route path="/run/:scenarioId" component={Run} />
-            <Route exact path="/editor/new" component={NewScenario} />
-            <Route path="/editor/:id" component={Editor} />
-            <Route exact path="/facilitator" component={Facilitator} />
-            <Route exact path="/admin" component={AccountAdmin} />
-            <Route exact path="/logout" component={Login} />
-            <Route exact path="/login" component={Login} />
-            <Route path="/login/new" component={CreateAccount} />
-        </Switch>
-    );
-};
 
 function App() {
     return (


### PR DESCRIPTION
@evmiguel @rwaldron this PR fixes our biggest mobile styling issues, namely no mobile friendly menu and uncentered scenario cards.

Proposed changes:
- Style changes for centering scenarios on the front end
- Add DesktopNav and MobileNav components. The mobile one includes a button for expanding/closing on click using handy dandy React Hooks!
- Refactor the menu to have most of its components in separate files 

![Screen Shot 2019-11-20 at 5 29 49 PM](https://user-images.githubusercontent.com/7991694/69283926-633db600-0bbb-11ea-925e-6384576b5356.png)