### PR TITLE
Response Recall: text display preserves newlines

### DIFF
--- a/client/components/Slide/Components/ResponseRecall/Display.jsx
+++ b/client/components/Slide/Components/ResponseRecall/Display.jsx
@@ -39,7 +39,7 @@ class Display extends React.Component {
                 : 'Loading your previous response'
             : 'Participant response will appear here.';
 
-        return <Message content={content} />;
+        return <Message style={{ whiteSpace: 'pre-wrap' }} content={content} />;
     }
 }
 


### PR DESCRIPTION
Before: 

![image](https://user-images.githubusercontent.com/27985/69347957-5fee0d00-0c43-11ea-9d61-ddc634a07047.png)

After: 

![image](https://user-images.githubusercontent.com/27985/69347970-63819400-0c43-11ea-8f6a-f3b34b87b6fd.png)
