### PR TITLE
Audio Response: update to match ui of other response components

### DIFF
--- a/client/components/Slide/Components/AudioResponse/Display.jsx
+++ b/client/components/Slide/Components/AudioResponse/Display.jsx
@@ -1,7 +1,7 @@
 import { type } from './type';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Button, Label, Icon } from 'semantic-ui-react';
+import { Button, Form, Icon, Segment, TextArea } from 'semantic-ui-react';
 import MicRecorder from 'mic-recorder-to-mp3';
 import { detect } from 'detect-browser';
 import { connect } from 'react-redux';
@@ -75,40 +75,46 @@ class Display extends Component {
 
     render() {
         const { isRecording } = this.state;
-        const { prompt } = this.props;
-        return (
-            (this.browserSupported && (
-                <React.Fragment>
-                    <Label>
-                        <p>{prompt}</p>
-                        {!isRecording && (
-                            <Button
-                                basic
-                                color="black"
-                                toggle
-                                onClick={this.onStart}
-                            >
-                                <Icon
-                                    name="circle"
-                                    aria-label="Record an Audio Response"
-                                />
-                                Record Response
-                            </Button>
-                        )}
-                        {isRecording && (
-                            <Button basic negative onClick={this.onStop}>
-                                <Icon
-                                    name="stop circle"
-                                    aria-label="Record an Audio Response"
-                                />
-                                Stop Recording
-                            </Button>
-                        )}
-                    </Label>
+        const { prompt, responseId, onResponseChange } = this.props;
+        return this.browserSupported ? (
+            <React.Fragment>
+                <Segment>
+                    {!isRecording && (
+                        <Button basic toggle onClick={this.onStart}>
+                            <Icon
+                                name="circle"
+                                aria-label="Record an Audio Response"
+                            />
+                            {prompt}
+                        </Button>
+                    )}
+                    {isRecording && (
+                        <Button basic negative onClick={this.onStop}>
+                            <Icon
+                                name="stop circle"
+                                aria-label="Record an Audio Response"
+                            />
+                            Done
+                        </Button>
+                    )}
+                </Segment>
 
+                {this.state.blobURL && (
                     <audio src={this.state.blobURL} controls="controls" />
-                </React.Fragment>
-            )) || <p>Please switch to Chrome or Firefox to record audio.</p>
+                )}
+            </React.Fragment>
+        ) : (
+            <Segment>
+                <Form>
+                    <Form.Field>
+                        <TextArea
+                            name={responseId}
+                            placeholder="Type your response here"
+                            onChange={onResponseChange}
+                        />
+                    </Form.Field>
+                </Form>
+            </Segment>
         );
     }
 }

--- a/client/components/Slide/Components/AudioResponse/Editor.jsx
+++ b/client/components/Slide/Components/AudioResponse/Editor.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Form, Label, TextArea } from 'semantic-ui-react';
+import { Container, Form, Input, Message, Popup } from 'semantic-ui-react';
 import { type } from './type';
 import './AudioResponse.css';
 
@@ -26,18 +26,23 @@ class AudioResponseEditor extends Component {
         const { prompt } = this.state;
         const { onTextAreaChange } = this;
         return (
-            <React.Fragment>
-                <Form>
-                    <Label>
-                        Audio Prompt:
-                        <TextArea
-                            name="prompt"
-                            value={prompt}
-                            onChange={onTextAreaChange}
-                        />
-                    </Label>
-                </Form>
-            </React.Fragment>
+            <Form>
+                <Container fluid>
+                    <Popup
+                        content="This is the label that will appear on the Audio Prompt button."
+                        trigger={
+                            <Input
+                                label="Audio Prompt:"
+                                name="prompt"
+                                value={prompt}
+                                onChange={onTextAreaChange}
+                            />
+                        }
+                    />
+
+                    <Message content="Note: This component will fallback to a text input prompt when Audio recording is not supported." />
+                </Container>
+            </Form>
         );
     }
 }

--- a/client/components/Slide/Components/AudioResponse/index.js
+++ b/client/components/Slide/Components/AudioResponse/index.js
@@ -1,7 +1,7 @@
 import { type } from './type';
 export { type };
 export const defaultValue = ({ responseId }) => ({
-    prompt: 'Provide a prompt for users to respond to here.',
+    prompt: 'Click then speak',
     responseId,
     type
 });


### PR DESCRIPTION
In Chrome: 

![image](https://user-images.githubusercontent.com/27985/69370150-609a9980-0c6b-11ea-93fa-eb4f8396f2ae.png)

In Mobile Safari: 

![image](https://user-images.githubusercontent.com/27985/69370162-64c6b700-0c6b-11ea-9245-0c619b59872d.png)

In the editor: 

![image](https://user-images.githubusercontent.com/27985/69370203-7c05a480-0c6b-11ea-8386-60b03dce9bf4.png)
![image](https://user-images.githubusercontent.com/27985/69370349-cd159880-0c6b-11ea-874b-dddcd1795eb3.png)


![image](https://user-images.githubusercontent.com/27985/69370341-c8e97b00-0c6b-11ea-854d-9a9805c4ab65.png)
