### PR TITLE
Run: use a wider card to fill more space on mobile view

### DIFF
--- a/client/components/Scenario/Scenario.css
+++ b/client/components/Scenario/Scenario.css
@@ -4,7 +4,7 @@
 }
 
 .ui.card.scenario__card--run {
-    width: 80vw;
+    width: 93vw;
     height: 85vh;
     max-width: 500px;
     margin-top: 2vh;


### PR DESCRIPTION
Before: 

![image](https://user-images.githubusercontent.com/27985/69454143-7e333600-0d33-11ea-9018-b6e8140397ae.png)


After: 

![image](https://user-images.githubusercontent.com/27985/69454150-81c6bd00-0d33-11ea-9d0a-c11fd878b587.png)
