### PR TITLE
Bug: don't allow prompt response submission when required prompts are present, unless explicitly "skipped"

### DIFF
--- a/client/components/Scenario/ContentSlide.jsx
+++ b/client/components/Scenario/ContentSlide.jsx
@@ -31,7 +31,9 @@ class ContentSlide extends React.Component {
         };
 
         this.onSkip = this.onSkip.bind(this);
-        this.onResponseChange = this.onResponseChange.bind(this);
+        this.onInterceptResponseChange = this.onInterceptResponseChange.bind(
+            this
+        );
     }
 
     onSkip(event) {
@@ -56,7 +58,7 @@ class ContentSlide extends React.Component {
         onClickNext();
     }
 
-    onResponseChange(event, data) {
+    onInterceptResponseChange(event, data) {
         const { name, value } = data;
         const { pending, required } = this.state;
 
@@ -64,16 +66,12 @@ class ContentSlide extends React.Component {
         // was marked required, and the value isn't empty,
         // then it can be removed from the list.
         if (required.includes(name)) {
-            if (value !== '') {
-                if (pending.includes(name)) {
-                    pending.splice(pending.indexOf(name), 1);
-                }
+            if (value !== '' && pending.includes(name)) {
+                pending.splice(pending.indexOf(name), 1);
             } else {
                 // Otherwise, if it is not empty, but was
                 // previously removed, add it back.
-                if (!pending.includes(name)) {
-                    pending.push(name);
-                }
+                pending.push(name);
             }
         }
 
@@ -90,7 +88,7 @@ class ContentSlide extends React.Component {
             run,
             slide
         } = this.props;
-        const { onResponseChange, onSkip } = this;
+        const { onInterceptResponseChange, onSkip } = this;
         const cardClass = run ? 'scenario__card--run' : 'scenario__card';
         const runOnly = run ? { run } : {};
         const hasPrompt = slide.components.some(
@@ -134,7 +132,7 @@ class ContentSlide extends React.Component {
                     <SlideComponentsList
                         {...runOnly}
                         components={slide.components}
-                        onResponseChange={onResponseChange}
+                        onResponseChange={onInterceptResponseChange}
                     />
                     <Popup
                         content="Go back to the previous slide"
@@ -161,7 +159,7 @@ class ContentSlide extends React.Component {
                                         <Button
                                             color="yellow"
                                             onClick={onSkip}
-                                            content="Skip"
+                                            content="Choose to Skip"
                                         />
                                     }
                                 />

--- a/client/components/Scenario/ContentSlide.jsx
+++ b/client/components/Scenario/ContentSlide.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { Button, Card } from 'semantic-ui-react';
+import { Button, Card, Icon, Popup } from 'semantic-ui-react';
 import { setRun } from '@client/actions';
 
 import SlideComponentsList from '@components/SlideComponentsList';
@@ -9,7 +9,29 @@ import SlideComponentsList from '@components/SlideComponentsList';
 class ContentSlide extends React.Component {
     constructor(props) {
         super(props);
+
+        const {
+            slide: { components }
+        } = this.props;
+
+        const required = components.reduce((accum, component) => {
+            if (component.required) {
+                accum.push(component.responseId);
+            }
+            return accum;
+        }, []);
+
+        this.state = {
+            // Provides a reference to compare
+            // prompt responseIds as the value
+            // changes.
+            required,
+            // Tracks prompt input, but must be a copy
+            pending: required.slice()
+        };
+
         this.onSkip = this.onSkip.bind(this);
+        this.onResponseChange = this.onResponseChange.bind(this);
     }
 
     onSkip(event) {
@@ -34,8 +56,41 @@ class ContentSlide extends React.Component {
         onClickNext();
     }
 
+    onResponseChange(event, data) {
+        const { name, value } = data;
+        const { pending, required } = this.state;
+
+        // If we have a response change for a responseId that
+        // was marked required, and the value isn't empty,
+        // then it can be removed from the list.
+        if (required.includes(name)) {
+            if (value !== '') {
+                if (pending.includes(name)) {
+                    pending.splice(pending.indexOf(name), 1);
+                }
+            } else {
+                // Otherwise, if it is not empty, but was
+                // previously removed, add it back.
+                if (!pending.includes(name)) {
+                    pending.push(name);
+                }
+            }
+        }
+
+        this.setState({ pending });
+        this.props.onResponseChange(event, data);
+    }
+
     render() {
-        const { isLastSlide, onResponseChange, run, slide } = this.props;
+        const { pending } = this.state;
+        const {
+            isLastSlide,
+            onClickNext,
+            onClickBack,
+            run,
+            slide
+        } = this.props;
+        const { onResponseChange, onSkip } = this;
         const cardClass = run ? 'scenario__card--run' : 'scenario__card';
         const runOnly = run ? { run } : {};
         const hasPrompt = slide.components.some(
@@ -43,9 +98,30 @@ class ContentSlide extends React.Component {
         );
 
         const proceedButtonLabel = hasPrompt ? 'Submit' : 'Next';
-        const finishOrProceedLabel = isLastSlide
-            ? 'Finish'
-            : proceedButtonLabel;
+        const submitNextOrFinish = isLastSlide ? 'Finish' : proceedButtonLabel;
+
+        const awaitingRequiredPrompts = (
+            <React.Fragment>
+                <Icon name="asterisk" /> Required
+            </React.Fragment>
+        );
+
+        const color = pending.length ? 'red' : 'green';
+        const content = pending.length
+            ? awaitingRequiredPrompts
+            : submitNextOrFinish;
+        const onClick = pending.length ? () => {} : onClickNext;
+
+        const fwdButtonProps = {
+            color,
+            content,
+            onClick
+        };
+        let fwdButtonTip = `Submit response and go to next slide`;
+
+        fwdButtonTip += pending.length
+            ? ` (${pending.length} required responses are not complete)`
+            : '';
 
         return (
             <Card id={slide.id} key={slide.id} centered className={cardClass}>
@@ -60,25 +136,34 @@ class ContentSlide extends React.Component {
                         components={slide.components}
                         onResponseChange={onResponseChange}
                     />
-
-                    <Button.Group>
-                        <Button
-                            color="grey"
-                            onClick={this.props.onClickBack}
-                            content={'Back'}
-                        />
-                        <Button
-                            color="green"
-                            onClick={this.props.onClickNext}
-                            content={finishOrProceedLabel}
+                    <Popup
+                        content="Go back to the previous slide"
+                        trigger={
+                            <Button
+                                floated="left"
+                                color="grey"
+                                onClick={onClickBack}
+                                content={'Back'}
+                            />
+                        }
+                    />
+                    <Button.Group floated="right">
+                        <Popup
+                            content={fwdButtonTip}
+                            trigger={<Button {...fwdButtonProps} />}
                         />
                         {hasPrompt && (
                             <React.Fragment>
                                 <Button.Or />
-                                <Button
-                                    color="yellow"
-                                    onClick={this.onSkip}
-                                    content="Skip"
+                                <Popup
+                                    content="Skip these prompts and go to next slide."
+                                    trigger={
+                                        <Button
+                                            color="yellow"
+                                            onClick={onSkip}
+                                            content="Skip"
+                                        />
+                                    }
                                 />
                             </React.Fragment>
                         )}

--- a/client/components/Slide/Components/AudioResponse/Card.jsx
+++ b/client/components/Slide/Components/AudioResponse/Card.jsx
@@ -4,11 +4,11 @@ import { Popup, Icon } from 'semantic-ui-react';
 const AudioResponseCard = () => (
     <Popup
         content="An audio recorder for users to record responses."
-        header="Audio Response"
+        header="Audio Response Prompt"
         trigger={
             <React.Fragment>
-                <Icon name="microphone" aria-label="Audio Response" />
-                Audio Response
+                <Icon name="microphone" aria-label="Audio Response Prompt" />
+                Audio Response Prompt
             </React.Fragment>
         }
     />

--- a/client/components/Slide/Components/AudioResponse/Editor.jsx
+++ b/client/components/Slide/Components/AudioResponse/Editor.jsx
@@ -1,31 +1,45 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Container, Form, Input, Message, Popup } from 'semantic-ui-react';
+import {
+    Checkbox,
+    Container,
+    Form,
+    Input,
+    Message,
+    Popup
+} from 'semantic-ui-react';
 import { type } from './type';
 import './AudioResponse.css';
 
 class AudioResponseEditor extends Component {
     constructor(props) {
         super(props);
-        const { prompt, responseId } = props.value;
+        const { prompt, required, responseId } = props.value;
         this.state = {
             prompt,
+            required,
             responseId
         };
-
-        this.onTextAreaChange = this.onTextAreaChange.bind(this);
+        this.onPromptChange = this.onPromptChange.bind(this);
+        this.onRequirementChange = this.onRequirementChange.bind(this);
     }
 
-    onTextAreaChange(event, { name, value }) {
-        this.setState({ [name]: value }, () => {
-            const { prompt, responseId } = this.state;
-            this.props.onChange({ type, prompt, responseId });
-        });
+    updateState() {
+        const { prompt, required, responseId } = this.state;
+        this.props.onChange({ prompt, required, responseId, type });
+    }
+
+    onRequirementChange(event, { checked }) {
+        this.setState({ required: checked }, this.updateState);
+    }
+
+    onPromptChange(event, { value }) {
+        this.setState({ prompt: value }, this.updateState);
     }
 
     render() {
-        const { prompt } = this.state;
-        const { onTextAreaChange } = this;
+        const { prompt, required } = this.state;
+        const { onPromptChange, onRequirementChange } = this;
         return (
             <Form>
                 <Container fluid>
@@ -36,12 +50,19 @@ class AudioResponseEditor extends Component {
                                 label="Audio Prompt:"
                                 name="prompt"
                                 value={prompt}
-                                onChange={onTextAreaChange}
+                                onChange={onPromptChange}
                             />
                         }
                     />
 
                     <Message content="Note: This component will fallback to a text input prompt when Audio recording is not supported." />
+
+                    <Checkbox
+                        name="required"
+                        label="Required?"
+                        checked={required}
+                        onChange={onRequirementChange}
+                    />
                 </Container>
             </Form>
         );
@@ -49,13 +70,14 @@ class AudioResponseEditor extends Component {
 }
 
 AudioResponseEditor.propTypes = {
+    onChange: PropTypes.func.isRequired,
     scenarioId: PropTypes.string,
     value: PropTypes.shape({
-        type: PropTypes.oneOf([type]),
         prompt: PropTypes.string,
-        responseId: PropTypes.string
-    }),
-    onChange: PropTypes.func.isRequired
+        required: PropTypes.bool,
+        responseId: PropTypes.string,
+        type: PropTypes.oneOf([type])
+    })
 };
 
 export default AudioResponseEditor;

--- a/client/components/Slide/Components/AudioResponse/index.js
+++ b/client/components/Slide/Components/AudioResponse/index.js
@@ -2,6 +2,7 @@ import { type } from './type';
 export { type };
 export const defaultValue = ({ responseId }) => ({
     prompt: 'Click then speak',
+    required: false,
     responseId,
     type
 });

--- a/client/components/Slide/Components/AudioResponse/index.js
+++ b/client/components/Slide/Components/AudioResponse/index.js
@@ -2,7 +2,7 @@ import { type } from './type';
 export { type };
 export const defaultValue = ({ responseId }) => ({
     prompt: 'Click then speak',
-    required: false,
+    required: true,
     responseId,
     type
 });

--- a/client/components/Slide/Components/MultiButtonResponse/Display.jsx
+++ b/client/components/Slide/Components/MultiButtonResponse/Display.jsx
@@ -1,13 +1,18 @@
 import { type } from './type';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button, List, Message } from 'semantic-ui-react';
+import { Button, Header, List, Segment } from 'semantic-ui-react';
+import PromptRequiredLabel from '../PromptRequiredLabel';
 
 class Display extends React.Component {
     constructor(props) {
         super(props);
-        this.onClick = this.onClick.bind(this);
+
+        this.state = {
+            value: ''
+        };
         this.created_at = new Date().toISOString();
+        this.onClick = this.onClick.bind(this);
     }
 
     onClick(event, { name, value }) {
@@ -19,33 +24,41 @@ class Display extends React.Component {
             value,
             type
         });
+
+        this.setState({ value });
     }
 
     render() {
-        const { buttons, prompt, responseId } = this.props;
+        const { buttons, prompt, required, responseId } = this.props;
+        const { value } = this.state;
         const { onClick } = this;
-
+        const fulfilled = value ? true : false;
+        const header = (
+            <React.Fragment>
+                {prompt}{' '}
+                {required && <PromptRequiredLabel fulfilled={fulfilled} />}
+            </React.Fragment>
+        );
         return (
-            <Message
-                header={prompt}
-                content={
-                    <List>
-                        {buttons &&
-                            buttons.map(({ display, value }, index) => (
-                                <List.Item key={`list.item-${index}`}>
-                                    <Button
-                                        fluid
-                                        key={`button-${index}`}
-                                        content={display}
-                                        name={responseId}
-                                        value={value}
-                                        onClick={onClick}
-                                    />
-                                </List.Item>
-                            ))}
-                    </List>
-                }
-            />
+            <Segment>
+                <Header as="h3">{header}</Header>
+
+                <List>
+                    {buttons &&
+                        buttons.map(({ display, value }, index) => (
+                            <List.Item key={`list.item-${index}`}>
+                                <Button
+                                    fluid
+                                    key={`button-${index}`}
+                                    content={display}
+                                    name={responseId}
+                                    value={value}
+                                    onClick={onClick}
+                                />
+                            </List.Item>
+                        ))}
+                </List>
+            </Segment>
         );
     }
 }
@@ -53,6 +66,7 @@ class Display extends React.Component {
 Display.propTypes = {
     buttons: PropTypes.array,
     prompt: PropTypes.string,
+    required: PropTypes.bool,
     responseId: PropTypes.string,
     onResponseChange: PropTypes.func,
     type: PropTypes.oneOf([type]).isRequired

--- a/client/components/Slide/Components/MultiButtonResponse/Editor.jsx
+++ b/client/components/Slide/Components/MultiButtonResponse/Editor.jsx
@@ -1,6 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button, Form, Icon, Input, List, Menu } from 'semantic-ui-react';
+import {
+    Checkbox,
+    Button,
+    Form,
+    Icon,
+    Input,
+    List,
+    Menu
+} from 'semantic-ui-react';
 import { type } from './type';
 import Sortable from 'react-sortablejs';
 import EditorMenu from '@components/EditorMenu';
@@ -18,12 +26,14 @@ class MultiButtonResponseEditor extends React.Component {
                 */
             ],
             prompt = '',
+            required,
             responseId = ''
         } = props.value;
 
         this.state = {
             buttons,
             prompt,
+            required,
             responseId
         };
 
@@ -33,18 +43,24 @@ class MultiButtonResponseEditor extends React.Component {
         this.onChangePrompt = this.onChangePrompt.bind(this);
         this.onDeleteButton = this.onDeleteButton.bind(this);
         this.onFocusButtonDetail = this.onFocusButtonDetail.bind(this);
+        this.onRequirementChange = this.onRequirementChange.bind(this);
 
         this.updateState = this.updateState.bind(this);
     }
 
     updateState() {
-        const { prompt, buttons, responseId } = this.state;
+        const { prompt, buttons, required, responseId } = this.state;
         this.props.onChange({
             type,
             prompt,
             buttons,
+            required,
             responseId
         });
+    }
+
+    onRequirementChange(event, { name, checked }) {
+        this.setState({ [name]: checked }, this.updateState);
     }
 
     onAddButton() {
@@ -101,7 +117,7 @@ class MultiButtonResponseEditor extends React.Component {
     }
 
     render() {
-        const { buttons, prompt } = this.state;
+        const { buttons, prompt, required } = this.state;
         const {
             onAddButton,
             onChangeButtonDetail,
@@ -109,6 +125,7 @@ class MultiButtonResponseEditor extends React.Component {
             onChangePrompt,
             onDeleteButton,
             onFocusButtonDetail,
+            onRequirementChange,
             updateState
         } = this;
         return (
@@ -181,20 +198,27 @@ class MultiButtonResponseEditor extends React.Component {
                         })}
                     </Sortable>
                 </List>
+                <Checkbox
+                    name="required"
+                    label="Required?"
+                    checked={required}
+                    onChange={onRequirementChange}
+                />
             </Form>
         );
     }
 }
 
 MultiButtonResponseEditor.propTypes = {
+    onChange: PropTypes.func.isRequired,
     scenarioId: PropTypes.string,
     value: PropTypes.shape({
         buttons: PropTypes.array,
         prompt: PropTypes.string,
+        required: PropTypes.bool,
         responseId: PropTypes.string,
         type: PropTypes.oneOf([type])
-    }),
-    onChange: PropTypes.func.isRequired
+    })
 };
 
 export default MultiButtonResponseEditor;

--- a/client/components/Slide/Components/MultiButtonResponse/index.js
+++ b/client/components/Slide/Components/MultiButtonResponse/index.js
@@ -1,6 +1,7 @@
 import { type } from './type';
 export { type };
 export const defaultValue = ({ responseId }) => ({
+    required: false,
     responseId,
     type
 });

--- a/client/components/Slide/Components/MultiButtonResponse/index.js
+++ b/client/components/Slide/Components/MultiButtonResponse/index.js
@@ -1,7 +1,7 @@
 import { type } from './type';
 export { type };
 export const defaultValue = ({ responseId }) => ({
-    required: false,
+    required: true,
     responseId,
     type
 });

--- a/client/components/Slide/Components/PromptRequiredLabel/PromptRequiredLabel.css
+++ b/client/components/Slide/Components/PromptRequiredLabel/PromptRequiredLabel.css
@@ -1,0 +1,4 @@
+.promptrequiredlabel__icon-margin,
+.promptrequiredlabel__icon-margin:only-child {
+    margin-right: 0rem !important;
+}

--- a/client/components/Slide/Components/PromptRequiredLabel/index.jsx
+++ b/client/components/Slide/Components/PromptRequiredLabel/index.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Icon, Label } from 'semantic-ui-react';
+import './PromptRequiredLabel.css';
+
+const PromptRequiredLabel = ({ fulfilled }) => {
+    const color = fulfilled ? 'green' : 'red';
+    const name = fulfilled ? 'check' : 'asterisk';
+
+    return (
+        <Label color={color} floating>
+            <Icon name={name} className="promptrequiredlabel__icon-margin" />
+        </Label>
+    );
+};
+
+PromptRequiredLabel.propTypes = {
+    fulfilled: PropTypes.bool
+};
+
+export default React.memo(PromptRequiredLabel);

--- a/client/components/Slide/Components/TextResponse/Display.jsx
+++ b/client/components/Slide/Components/TextResponse/Display.jsx
@@ -1,14 +1,17 @@
 import { type } from './type';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Form, Label, Segment, TextArea } from 'semantic-ui-react';
-
+import { Form, Header, Segment } from 'semantic-ui-react';
+import PromptRequiredLabel from '../PromptRequiredLabel';
 import './TextResponse.css';
 
 class Display extends Component {
     constructor(props) {
         super(props);
 
+        this.state = {
+            value: ''
+        };
         this.created_at = '';
         this.onFocus = this.onFocus.bind(this);
         this.onChange = this.onChange.bind(this);
@@ -20,33 +23,41 @@ class Display extends Component {
         }
     }
 
-    onChange(event, data) {
+    onChange(event, { name, value }) {
         const { created_at } = this;
         this.props.onResponseChange(event, {
-            ...data,
             created_at,
             ended_at: new Date().toISOString(),
-            type
+            name,
+            type,
+            value
         });
+
+        this.setState({ value });
     }
 
     render() {
-        const { prompt, placeholder, responseId } = this.props;
+        const { prompt, placeholder, required, responseId } = this.props;
+        const { value } = this.state;
         const { onFocus, onChange } = this;
+        const fulfilled = value ? true : false;
+        const header = (
+            <React.Fragment>
+                {prompt}{' '}
+                {required && <PromptRequiredLabel fulfilled={fulfilled} />}
+            </React.Fragment>
+        );
+
         return (
             <Segment>
+                <Header as="h3">{header}</Header>
                 <Form>
-                    <Form.Field>
-                        <Label as="label" className="textresponse__label">
-                            <p>{prompt}</p>
-                        </Label>
-                        <TextArea
-                            name={responseId}
-                            placeholder={placeholder}
-                            onFocus={onFocus}
-                            onChange={onChange}
-                        />
-                    </Form.Field>
+                    <Form.TextArea
+                        name={responseId}
+                        placeholder={placeholder}
+                        onFocus={onFocus}
+                        onChange={onChange}
+                    />
                 </Form>
             </Segment>
         );
@@ -54,10 +65,11 @@ class Display extends Component {
 }
 
 Display.propTypes = {
-    prompt: PropTypes.string,
-    placeholder: PropTypes.string,
-    responseId: PropTypes.string,
     onResponseChange: PropTypes.func,
+    placeholder: PropTypes.string,
+    prompt: PropTypes.string,
+    required: PropTypes.bool,
+    responseId: PropTypes.string,
     type: PropTypes.oneOf([type]).isRequired
 };
 

--- a/client/components/Slide/Components/TextResponse/Editor.jsx
+++ b/client/components/Slide/Components/TextResponse/Editor.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Container, Form } from 'semantic-ui-react';
+import { Checkbox, Container, Form } from 'semantic-ui-react';
 import { type } from './type';
 import './TextResponse.css';
 
@@ -10,20 +10,23 @@ class TextResponseEditor extends React.Component {
         const {
             prompt = 'Text Prompt (displayed before input field as label)',
             placeholder = 'Placeholder Text',
+            required,
             responseId = ''
         } = props.value;
         this.state = {
             prompt,
             placeholder,
+            required,
             responseId
         };
 
-        this.onTextAreaChange = this.onTextAreaChange.bind(this);
+        this.onTextareaChange = this.onTextareaChange.bind(this);
+        this.onRequirementChange = this.onRequirementChange.bind(this);
     }
 
     render() {
-        const { prompt, placeholder } = this.state;
-        const { onTextAreaChange } = this;
+        const { prompt, placeholder, required } = this.state;
+        const { onTextareaChange, onRequirementChange } = this;
         return (
             <Form>
                 <Container fluid>
@@ -31,36 +34,55 @@ class TextResponseEditor extends React.Component {
                         label="Prompt"
                         name="prompt"
                         value={prompt}
-                        onChange={onTextAreaChange}
+                        onChange={onTextareaChange}
                     />
                     <Form.TextArea
                         label="Placeholder"
                         name="placeholder"
                         value={placeholder}
-                        onChange={onTextAreaChange}
+                        onChange={onTextareaChange}
+                    />
+                    <Checkbox
+                        name="required"
+                        label="Required?"
+                        checked={required}
+                        onChange={onRequirementChange}
                     />
                 </Container>
             </Form>
         );
     }
 
-    onTextAreaChange(event, { name, value }) {
-        this.setState({ [name]: value }, () => {
-            const { prompt, placeholder, responseId } = this.state;
-            this.props.onChange({ type, prompt, placeholder, responseId });
+    updateState() {
+        const { prompt, placeholder, required, responseId } = this.state;
+        this.props.onChange({
+            type,
+            prompt,
+            placeholder,
+            required,
+            responseId
         });
+    }
+
+    onRequirementChange(event, { name, checked }) {
+        this.setState({ [name]: checked }, this.updateState);
+    }
+
+    onTextareaChange(event, { name, value }) {
+        this.setState({ [name]: value }, this.updateState);
     }
 }
 
 TextResponseEditor.propTypes = {
+    onChange: PropTypes.func.isRequired,
     scenarioId: PropTypes.string,
     value: PropTypes.shape({
-        type: PropTypes.oneOf([type]),
-        prompt: PropTypes.string,
         placeholder: PropTypes.string,
-        responseId: PropTypes.string
-    }),
-    onChange: PropTypes.func.isRequired
+        prompt: PropTypes.string,
+        required: PropTypes.bool,
+        responseId: PropTypes.string,
+        type: PropTypes.oneOf([type])
+    })
 };
 
 export default TextResponseEditor;

--- a/client/components/Slide/Components/TextResponse/index.js
+++ b/client/components/Slide/Components/TextResponse/index.js
@@ -2,8 +2,8 @@ import { type } from './type';
 export { type };
 export const defaultValue = ({ responseId }) => ({
     placeholder: 'Placeholder Text',
-    prompt: 'Text Prompt (displayed before input field as label)',
-    required: false,
+    prompt: 'Prompt (displayed before input field as label)',
+    required: true,
     responseId,
     type
 });

--- a/client/components/Slide/Components/TextResponse/index.js
+++ b/client/components/Slide/Components/TextResponse/index.js
@@ -3,6 +3,7 @@ export { type };
 export const defaultValue = ({ responseId }) => ({
     placeholder: 'Placeholder Text',
     prompt: 'Text Prompt (displayed before input field as label)',
+    required: false,
     responseId,
     type
 });


### PR DESCRIPTION
This PR relies on [Participant Run: simplify response, don't pave over responses with a skip, adds isSkip property to responses](https://github.com/bocoup/threeflows/pull/148) and must be rebased once that lands. 

There was a bug that allowed response prompts to be left empty when the "Submit" button was pressed, effectively by-passing the "intentional Skip" button. Since we can't know what prompts will need to be "required", this PR adds a checkbox to prompt components that allow the author to mark a prompt as "required". On the front end, ContentSlide will determine which components it has that are required and keep track of input to those components, releasing their pending "lock" when they have been satisfied. Once all pending "locks" are released, the "Submit" button will become active. 

![image](https://user-images.githubusercontent.com/27985/69551659-0e0ef500-0f6b-11ea-8883-14b3b86e8161.png)

![image](https://user-images.githubusercontent.com/27985/69551675-1404d600-0f6b-11ea-958c-e42d64fcde59.png)

![image](https://user-images.githubusercontent.com/27985/69551688-1a934d80-0f6b-11ea-8ebf-3457f23443ac.png)


