### PR TITLE
fix editor preview pane overflow by removing vert height

### DIFF
--- a/client/components/Editor/editor.css
+++ b/client/components/Editor/editor.css
@@ -6,7 +6,3 @@
     margin-top: 1rem;
     font-size: 1.1rem;
 }
-
-.editor__content-pane {
-    height: 83vh !important;
-}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/122117/69680269-6da6f680-1078-11ea-93a3-6c573d0fc902.png)

