### PR TITLE
Add component for front end user auth

### DIFF
--- a/client/actions/index.js
+++ b/client/actions/index.js
@@ -8,18 +8,18 @@ import {
     SET_USERS
 } from './types';
 
-export const logIn = username => ({
+export const logIn = userData => ({
     type: LOG_IN,
     payload: {
-        username,
+        ...userData,
         isLoggedIn: true
     }
 });
 
-export const logOut = username => ({
+export const logOut = userData => ({
     type: LOG_OUT,
     payload: {
-        username,
+        ...userData,
         isLoggedIn: false
     }
 });

--- a/client/components/ConfirmAuth/index.jsx
+++ b/client/components/ConfirmAuth/index.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { Route } from 'react-router-dom';
+import PropTypes from 'prop-types';
+
+const ConfirmAuth = ({
+    children,
+    isAuthorized,
+    permissions,
+    requiredPermission,
+    ...rest
+}) => {
+    const AuthConfirmed =
+        isAuthorized || permissions.includes(requiredPermission);
+
+    return (
+        <Route
+            {...rest}
+            render={() => {
+                return AuthConfirmed ? children : null;
+            }}
+        />
+    );
+};
+
+function mapStateToProps(state) {
+    const { isLoggedIn, username, permissions } = state.login;
+    return { isLoggedIn, username, permissions };
+}
+
+ConfirmAuth.propTypes = {
+    children: PropTypes.oneOfType([
+        PropTypes.arrayOf(PropTypes.node),
+        PropTypes.node
+    ]).isRequired,
+    isAuthorized: PropTypes.bool,
+    permissions: PropTypes.node,
+    requiredPermission: PropTypes.string
+};
+
+export default connect(
+    mapStateToProps,
+    null
+)(ConfirmAuth);

--- a/client/components/Login/index.jsx
+++ b/client/components/Login/index.jsx
@@ -72,11 +72,25 @@ class Login extends Component {
             }
         )).json();
 
+        const { permissions } = await (await fetch(
+            '/api/roles/permission'
+        )).json();
+
         if (error) {
             this.setState({ loginError });
             this.props.logOut('');
         } else {
-            Session.create({ username, timeout: Date.now() });
+            this.props.logIn({
+                username,
+                isLoggedIn: true,
+                permissions
+            });
+            Session.create({
+                username,
+                timeout: Date.now(),
+                permissions
+            });
+
             // Step outside of react to force a real reload
             // after login and session create
             location.href = from ? from.pathname : '/';
@@ -155,8 +169,8 @@ Login.propTypes = {
 };
 
 function mapStateToProps(state) {
-    const { isLoggedIn, username } = state.login;
-    return { isLoggedIn, username };
+    const { isLoggedIn, username, permissions } = state.login;
+    return { isLoggedIn, username, permissions };
 }
 
 const mapDispatchToProps = {

--- a/client/components/ScenarioEditor/index.jsx
+++ b/client/components/ScenarioEditor/index.jsx
@@ -11,6 +11,7 @@ import {
 } from 'semantic-ui-react';
 import { setScenario } from '@client/actions';
 
+import ConfirmAuth from '@client/components/ConfirmAuth';
 import './scenarioEditor.css';
 
 class ScenarioEditor extends Component {
@@ -79,6 +80,7 @@ class ScenarioEditor extends Component {
             );
             return;
         }
+
         this.setState({ saving: true });
         const data = {
             title: this.props.title,
@@ -165,26 +167,30 @@ class ScenarioEditor extends Component {
                             </Grid.Column>
                             <Grid.Column width={3}>
                                 {this.state.categories.length && (
-                                    <Form.Field>
-                                        <label>Categories</label>
-                                        <Dropdown
-                                            label="Categories"
-                                            name="categories"
-                                            placeholder="Select..."
-                                            fluid
-                                            multiple
-                                            selection
-                                            options={this.state.categories.map(
-                                                category => ({
-                                                    key: category.id,
-                                                    text: category.name,
-                                                    value: category.name
-                                                })
-                                            )}
-                                            defaultValue={this.props.categories}
-                                            onChange={this.onChange}
-                                        />
-                                    </Form.Field>
+                                    <ConfirmAuth requiredPermission="edit_scenario">
+                                        <Form.Field>
+                                            <label>Categories</label>
+                                            <Dropdown
+                                                label="Categories"
+                                                name="categories"
+                                                placeholder="Select..."
+                                                fluid
+                                                multiple
+                                                selection
+                                                options={this.state.categories.map(
+                                                    category => ({
+                                                        key: category.id,
+                                                        text: category.name,
+                                                        value: category.name
+                                                    })
+                                                )}
+                                                defaultValue={
+                                                    this.props.categories
+                                                }
+                                                onChange={this.onChange}
+                                            />
+                                        </Form.Field>
+                                    </ConfirmAuth>
                                 )}
                                 {/*
                                     TODO: create the same Dropdown style thing

--- a/client/components/ScenariosList/DeletedCard.jsx
+++ b/client/components/ScenariosList/DeletedCard.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Button, Card } from 'semantic-ui-react';
+import PropTypes from 'prop-types';
+
+const strike = { textDecoration: 'line-through' };
+
+const DeletedCard = ({ id, title, description }) => {
+    return (
+        <Card className="scenario__entry" key={id}>
+            <Card.Content>
+                <Card.Header style={strike}>{title}</Card.Header>
+                <Card.Description style={strike}>
+                    {description}
+                </Card.Description>
+            </Card.Content>
+            <Card.Content extra>
+                <Button.Group className="scenario__entry--edit-buttons">
+                    <Button>Restore</Button>
+                </Button.Group>
+            </Card.Content>
+        </Card>
+    );
+};
+
+DeletedCard.propTypes = {
+    id: PropTypes.node.isRequired,
+    title: PropTypes.string.isRequired,
+    description: PropTypes.string.isRequired
+};
+
+export default DeletedCard;

--- a/client/components/ScenariosList/ScenarioCard.jsx
+++ b/client/components/ScenariosList/ScenarioCard.jsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Button, Card } from 'semantic-ui-react';
+import PropTypes from 'prop-types';
+
+import ConfirmAuth from '@client/components/ConfirmAuth';
+import DeletedCard from './DeletedCard';
+
+const ScenarioCard = ({ scenario, isLoggedIn }) => {
+    const { id, title, description, deleted_at, user_is_author } = scenario;
+
+    return deleted_at ? (
+        <ConfirmAuth
+            isAuthorized={user_is_author}
+            requiredPermission="edit_scenario"
+        >
+            <DeletedCard id={id} title={title} description={description} />
+        </ConfirmAuth>
+    ) : (
+        <Card className="scenario__entry" key={id}>
+            <Card.Content>
+                <Card.Header>{title}</Card.Header>
+                <Card.Description>{description}</Card.Description>
+            </Card.Content>
+            <Card.Content extra>
+                <Button
+                    basic
+                    fluid
+                    color="black"
+                    as={Link}
+                    to={{ pathname: `/run/${id}` }}
+                    className="scenario__entry--button"
+                >
+                    Run
+                </Button>
+            </Card.Content>
+            {isLoggedIn && (
+                <Card.Content extra>
+                    <Button.Group className="scenario__entry--edit-buttons">
+                        <ConfirmAuth
+                            isAuthorized={user_is_author}
+                            requiredPermission="edit_scenario"
+                        >
+                            <Button
+                                basic
+                                color="black"
+                                className="scenario__entry--button"
+                                as={Link}
+                                to={{ pathname: `/editor/${id}` }}
+                            >
+                                Edit
+                            </Button>
+                        </ConfirmAuth>
+                        <Button
+                            basic
+                            color="black"
+                            className="scenario__entry--button"
+                            as={Link}
+                            to={{
+                                pathname: `/editor/copy`,
+                                state: {
+                                    scenarioCopyId: id
+                                }
+                            }}
+                        >
+                            Copy
+                        </Button>
+                    </Button.Group>
+                </Card.Content>
+            )}
+        </Card>
+    );
+};
+
+ScenarioCard.propTypes = {
+    scenario: PropTypes.object,
+    isLoggedIn: PropTypes.bool.isRequired
+};
+
+export default ScenarioCard;

--- a/client/components/ScenariosList/ScenarioEntries.jsx
+++ b/client/components/ScenariosList/ScenarioEntries.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import ScenarioCard from './ScenarioCard';
+
+const ScenarioEntries = ({ scenarios, isLoggedIn }) => {
+    if (!scenarios.length) return null;
+
+    return scenarios.map(scenario => {
+        return (
+            <ScenarioCard
+                key={scenario.id}
+                scenario={scenario}
+                isLoggedIn={isLoggedIn}
+            />
+        );
+    });
+};
+
+ScenarioCard.propTypes = {
+    scenarios: PropTypes.array,
+    isLoggedIn: PropTypes.bool.isRequired
+};
+
+export default ScenarioEntries;

--- a/client/components/ScenariosList/index.jsx
+++ b/client/components/ScenariosList/index.jsx
@@ -1,82 +1,11 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { Link } from 'react-router-dom';
-import { Button, Card, Grid, Loader } from 'semantic-ui-react';
+import { Card, Grid, Loader } from 'semantic-ui-react';
 import PropTypes from 'prop-types';
 
+import ScenarioEntries from './ScenarioEntries';
 import 'semantic-ui-css/semantic.min.css';
 import './ScenariosList.css';
-
-const ScenarioEntries = ({ scenarios, isLoggedIn }) => {
-    if (!scenarios.length) {
-        return null;
-    }
-
-    // only filter out scenario if there is a path
-    return scenarios.map(({ id, title, description, deleted_at }) => {
-        const strike = deleted_at ? { textDecoration: 'line-through' } : {};
-        return (
-            <Card className="scenario__entry" key={id}>
-                <Card.Content>
-                    <Card.Header style={strike}>{title}</Card.Header>
-                    <Card.Description style={strike}>
-                        {description}
-                    </Card.Description>
-                </Card.Content>
-                {!deleted_at && (
-                    <Card.Content extra>
-                        <Button
-                            basic
-                            fluid
-                            color="black"
-                            as={Link}
-                            to={{ pathname: `/run/${id}` }}
-                            className="scenario__entry--button"
-                        >
-                            Run
-                        </Button>
-                    </Card.Content>
-                )}
-                {!deleted_at && isLoggedIn && (
-                    <Card.Content extra>
-                        <Button.Group className="scenario__entry--edit-buttons">
-                            <Button
-                                basic
-                                color="black"
-                                className="scenario__entry--button"
-                                as={Link}
-                                to={{ pathname: `/editor/${id}` }}
-                            >
-                                Edit
-                            </Button>
-                            <Button
-                                basic
-                                color="black"
-                                className="scenario__entry--button"
-                                as={Link}
-                                to={{
-                                    pathname: `/editor/copy`,
-                                    state: {
-                                        scenarioCopyId: id
-                                    }
-                                }}
-                            >
-                                Copy
-                            </Button>
-                        </Button.Group>
-                    </Card.Content>
-                )}
-                {deleted_at && isLoggedIn && (
-                    <Card.Content extra>
-                        <Button.Group className="scenario__entry--edit-buttons">
-                            <Button>Restore</Button>
-                        </Button.Group>
-                    </Card.Content>
-                )}
-            </Card>
-        );
-    });
-};
 
 class ScenariosList extends Component {
     constructor(props) {

--- a/client/reducers/login.js
+++ b/client/reducers/login.js
@@ -1,20 +1,24 @@
 import { LOG_IN, LOG_OUT } from '@client/actions/types';
 import Session from '@client/util/session';
 
-const { username = '' } = Session.isSessionActive() ? Session.getSession() : {};
+const { username = '', permissions = [] } = Session.isSessionActive()
+    ? Session.getSession()
+    : {};
 const initialState = {
     isLoggedIn: !!username,
-    username
+    username,
+    permissions
 };
 
 export default function(state = initialState, action) {
     switch (action.type) {
         case LOG_IN: {
-            const { isLoggedIn, username } = action.payload;
+            const { isLoggedIn, username, permissions } = action.payload;
 
             return {
                 ...state,
                 username,
+                permissions,
                 isLoggedIn
             };
         }
@@ -24,6 +28,7 @@ export default function(state = initialState, action) {
             return {
                 ...state,
                 username,
+                permissions,
                 isLoggedIn
             };
         }

--- a/client/routes/Navigation.jsx
+++ b/client/routes/Navigation.jsx
@@ -1,12 +1,36 @@
 import React, { useState } from 'react';
 import { NavLink } from 'react-router-dom';
 import { Button, Dropdown, Icon, Menu } from 'semantic-ui-react';
-import ConfirmableLogoutMenuItem from '@client/components/Login/ConfirmableLogoutMenuItem';
 
+import ConfirmAuth from '@client/components/ConfirmAuth';
+import ConfirmableLogoutMenuItem from '@client/components/Login/ConfirmableLogoutMenuItem';
 import Session from '@client/util/session';
-const MOBILE_WIDTH = 767;
 
 Session.timeout();
+
+const MOBILE_WIDTH = 767;
+const restrictedNav = [
+    {
+        text: 'Create a Moment',
+        path: '/editor/new',
+        permission: 'create_scenario'
+    },
+    {
+        text: 'Cohorts Management',
+        path: '/cohorts',
+        permission: 'view_run_data'
+    },
+    {
+        text: 'Data Export',
+        path: '/cohorts',
+        permission: 'view_run_data'
+    },
+    {
+        text: 'Account Administration',
+        path: '/account-administration',
+        permission: 'edit_permissions'
+    }
+];
 
 const Navigation = () => {
     const [menuExpanded, setMenuExpanded] = useState(
@@ -18,6 +42,17 @@ const Navigation = () => {
             setMenuExpanded(true);
         }
     };
+    const authorizedNav = restrictedNav.map(
+        ({ text, path, permission }, index) => {
+            return (
+                <ConfirmAuth key={index} requiredPermission={permission}>
+                    <Menu.Item>
+                        <NavLink to={path}>{text}</NavLink>
+                    </Menu.Item>
+                </ConfirmAuth>
+            );
+        }
+    );
 
     return (
         <React.Fragment>
@@ -56,30 +91,12 @@ const Navigation = () => {
                             </Dropdown.Menu>
                         </Dropdown>
                     </Menu.Menu>
-                    {Session.isSessionActive() && (
-                        <React.Fragment>
-                            <Menu.Item>
-                                <NavLink exact to="/editor/new">
-                                    Create a Moment
-                                </NavLink>
-                            </Menu.Item>
-                            <Menu.Item>
-                                <NavLink to="/cohorts">
-                                    Cohorts Management
-                                </NavLink>
-                            </Menu.Item>
-                            <Menu.Item>
-                                <NavLink to="/researcher">Data Export</NavLink>
-                            </Menu.Item>
-                            <Menu.Item>
-                                <NavLink to="/account-administration">
-                                    Account Administration
-                                </NavLink>
-                            </Menu.Item>
-                            <ConfirmableLogoutMenuItem />
-                        </React.Fragment>
-                    )}
-                    {!Session.isSessionActive() && (
+
+                    {authorizedNav}
+
+                    {Session.isSessionActive() ? (
+                        <ConfirmableLogoutMenuItem />
+                    ) : (
                         <Menu.Item position="right">
                             <NavLink to="/login">Log in</NavLink>
                         </Menu.Item>

--- a/client/routes/Routes.jsx
+++ b/client/routes/Routes.jsx
@@ -1,16 +1,18 @@
 import React from 'react';
 import { Route, Switch } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import ScenariosList from '@client/components/ScenariosList';
-import Editor from '@client/components/Editor';
-import Facilitator from '@client/components/Facilitator';
+
 import AccountAdmin from '@client/components/AccountAdmin';
-import Login from '@client/components/Login';
-import LoginRoutePromptModal from '@client/components/Login/LoginRoutePromptModal';
 import CreateAccount from '@client/components/CreateAccount';
 import CreateAnonymousAccount from '@client/components/CreateAccount/CreateAnonymousAccount';
+import ConfirmAuth from '@client/components/ConfirmAuth';
+import Editor from '@client/components/Editor';
+import Facilitator from '@client/components/Facilitator';
+import Login from '@client/components/Login';
+import LoginRoutePromptModal from '@client/components/Login/LoginRoutePromptModal';
 import Run from '@client/components/Run';
 import Researcher from '@client/components/Researcher';
+import ScenariosList from '@client/components/ScenariosList';
 
 import Session from '@client/util/session';
 
@@ -58,14 +60,32 @@ const Routes = () => {
             <InterceptAnonymizableRoute path="/run/:scenarioId">
                 <Route component={Run} />
             </InterceptAnonymizableRoute>
-            <Route exact path="/editor/new" component={NewScenario} />
-            <Route path="/editor/:id" component={Editor} />
-            <Route exact path="/cohorts" component={Facilitator} />
-            <Route
+            <ConfirmAuth
+                path="/editor/new"
+                requiredPermission="create_scenario"
+            >
+                <Route component={NewScenario} />
+            </ConfirmAuth>
+            <ConfirmAuth
+                path="/editor/:id"
+                requiredPermission="create_scenario"
+            >
+                <Route component={Editor} />
+            </ConfirmAuth>
+            <ConfirmAuth
+                exact
+                path="/cohorts"
+                requiredPermission="view_run_data"
+            >
+                <Route component={Facilitator} />
+            </ConfirmAuth>
+            <ConfirmAuth
                 exact
                 path="/account-administration"
-                component={AccountAdmin}
-            />
+                requiredPermission="edit_permissions"
+            >
+                <Route component={AccountAdmin} />
+            </ConfirmAuth>
             <Route exact path="/logout" component={Logout} />
             <Route exact path="/login" component={Login} />
             <Route exact path="/login/new" component={CreateAccount} />

--- a/client/util/session.js
+++ b/client/util/session.js
@@ -1,16 +1,20 @@
 const TIMEOUT = 1000 * 60 * 60;
 
 const getSession = () => {
-    const { timestamp = Date.now(), username = '' } = JSON.parse(
-        localStorage.getItem('session')
-    ) || {
+    const {
+        timestamp = Date.now(),
+        username = '',
+        permissions = []
+    } = JSON.parse(localStorage.getItem('session')) || {
         timestamp: '',
-        username: ''
+        username: '',
+        permissions: []
     };
 
     return {
         timestamp,
-        username
+        username,
+        permissions
     };
 };
 

--- a/server/migrations/20191125213104-role-permission.js
+++ b/server/migrations/20191125213104-role-permission.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const sqlFile = require('./helpers/sql-file')(__filename);
+exports.up = function(db) {
+    return db.runSql(sqlFile.up);
+};
+exports.down = function(db) {
+    return db.runSql(sqlFile.down);
+};
+exports._meta = {
+    version: 1
+};

--- a/server/migrations/sql/20191125213104-role-permission.sql
+++ b/server/migrations/sql/20191125213104-role-permission.sql
@@ -1,0 +1,7 @@
+CREATE TABLE role_permission (
+    role VARCHAR NOT NULL CHECK (role IN ('super_admin', 'admin', 'researcher', 'facilitator', 'participant')),
+    permission VARCHAR NOT NULL
+);
+---
+
+DROP TABLE role_permission;

--- a/server/package.json
+++ b/server/package.json
@@ -21,6 +21,7 @@
     "dev": "nodemon index.js",
     "lint": "eslint --ext js .",
     "prettier": "prettier --write \"**/*.js\"",
+    "seed:permissions": "node seed/rolePermissions.js",
     "test": "yarn workspace test run test:server"
   },
   "dependencies": {

--- a/server/seed/permissions.json
+++ b/server/seed/permissions.json
@@ -1,0 +1,6 @@
+{
+    "create_scenario": ["super_admin", "admin", "researcher", "facilitator"],
+    "edit_scenario": ["super_admin", "admin"],
+    "edit_permissions": ["super_admin", "admin"],
+    "view_run_data": ["super_admin", "admin", "researcher", "facilitator"]
+}

--- a/server/seed/rolePermissions.js
+++ b/server/seed/rolePermissions.js
@@ -1,0 +1,14 @@
+const { addRolePermissions } = require('../service/roles/db');
+const rolePermissionData = require('./permissions.json');
+
+async function seedPermissions() {
+    Object.entries(rolePermissionData).map(async ([permission, roles]) => {
+        roles.forEach(async role => {
+            const result = await addRolePermissions(role, permission);
+            // eslint-disable-next-line no-console
+            console.log(`${permission}: ${role}`, result);
+        });
+    });
+}
+
+seedPermissions();

--- a/server/service/roles/endpoints.js
+++ b/server/service/roles/endpoints.js
@@ -31,6 +31,16 @@ exports.getUserRoles = asyncMiddleware(async function getUserRolesAsync(
     res.json(userRoleData);
 });
 
+exports.getUserPermissions = asyncMiddleware(async function getUserPermissions(
+    req,
+    res
+) {
+    const userId = req.session.user.id;
+    const userPermissions = await db.getUserPermissions(userId);
+
+    res.json(userPermissions);
+});
+
 exports.addUserRoles = asyncMiddleware(async function addUserRolesAsync(
     req,
     res

--- a/server/service/roles/index.js
+++ b/server/service/roles/index.js
@@ -3,36 +3,39 @@ const { Router } = require('express');
 const { validateRequestBody } = require('../../util/requestValidation');
 const { requireUserRole, checkCanEditUserRoles } = require('./middleware');
 
-const rolesRouter = Router();
+const router = Router();
 
 const {
     getAllUsersRoles,
     getUserRoles,
+    getUserPermissions,
     addUserRoles,
     deleteUserRoles,
     setUserRoles
 } = require('./endpoints');
 
-rolesRouter.get('/', [requireUserRole('admin'), getAllUsersRoles]);
+router.get('/', [requireUserRole('admin'), getAllUsersRoles]);
 
-rolesRouter.get('/:user_id', [requireUserRole('admin'), getUserRoles]);
+router.get('/permission', [getUserPermissions]);
 
-rolesRouter.put('/:user_id', [
+router.get('/:user_id', [requireUserRole('admin'), getUserRoles]);
+
+router.put('/:user_id', [
     checkCanEditUserRoles(req => req.params.user_id),
     validateRequestBody,
     setUserRoles
 ]);
 
-rolesRouter.post('/add', [
+router.post('/add', [
     checkCanEditUserRoles(req => req.session.user.id),
     validateRequestBody,
     addUserRoles
 ]);
 
-rolesRouter.post('/delete', [
+router.post('/delete', [
     checkCanEditUserRoles(req => req.session.user.id),
     validateRequestBody,
     deleteUserRoles
 ]);
 
-module.exports = rolesRouter;
+module.exports = router;


### PR DESCRIPTION
@rwaldron here is my PR for gating front end features for users based on their role or whether they're the author of a scenario. Let me know what you think, and I can also go over these in person if it's a lot of changes to take in!

Steps to test:
- Pull down branch and run `yarn db-migrate-up` to add the permissions table.
- Run `seed:permissions` in the `/server` directory to seed permissions in that table (I didn't make this a root directory yarn command, but I can). 
- Try users with different roles and who are the authors of some scenarios and not others.

My proposed changes:
- Add `ConfrimAuth` component that can wrap around nav items and other components and check whether a user should have access or not. If not, nothing is rendered.
- Add `role_permission` table to store what permissions each role should have
- Add a script to seed the role_permission database with permissions we need so far
- Add permissions API endpoint so that we can get a user's permssions in the front end and save it in Redux
- Hide the categories UI and deleted scenarios unless you are an admin or the author.
- Refactor the scenarios list into separate files, it was getting really nested when I tried to confirm auth on viewing deleted scenarios

Writing this out, it's a lot! Let me know if I can help explain anything.