### PR TITLE
Scenario Editor: widen title, description, category.

### DIFF
--- a/client/components/ScenarioEditor/index.jsx
+++ b/client/components/ScenarioEditor/index.jsx
@@ -119,8 +119,8 @@ class ScenarioEditor extends Component {
             <Form size={'big'}>
                 <Container fluid>
                     <Grid columns={2} divided>
-                        <Grid.Row>
-                            <Grid.Column width={8}>
+                        <Grid.Row className="scenarioeditor__grid-nowrap">
+                            <Grid.Column width={9}>
                                 <Form.Input
                                     focus
                                     required
@@ -165,7 +165,10 @@ class ScenarioEditor extends Component {
                                     </Button>
                                 )}
                             </Grid.Column>
-                            <Grid.Column width={3}>
+                            <Grid.Column
+                                width={3}
+                                className="scenarioeditor__categories-minwidth"
+                            >
                                 {this.state.categories.length && (
                                     <ConfirmAuth requiredPermission="edit_scenario">
                                         <Form.Field>

--- a/client/components/ScenarioEditor/scenarioEditor.css
+++ b/client/components/ScenarioEditor/scenarioEditor.css
@@ -1,3 +1,7 @@
-.tm__scenario-save {
-    margin: 1rem 0;
+.scenarioeditor__categories-minwidth {
+    min-width: 18rem !important;
+}
+
+.scenarioeditor__grid-nowrap {
+    flex-wrap: nowrap !important;
 }


### PR DESCRIPTION
- Removes unused style
- Add min-width
- Add flex-wrap: nowrap
- Widen Grid Columns


The min-width prevents the "Categories" from looking like this: 
![image](https://user-images.githubusercontent.com/27985/70063327-9158c800-15b5-11ea-8ce8-f6aadcd69eba.png)

But when you set a min-width, it could result in this: 

![image](https://user-images.githubusercontent.com/27985/70063410-b5b4a480-15b5-11ea-8d5f-02dc227e7e55.png)


So you must set `flex-wrap: nowrap`. 
