### PR TITLE
EntrySlide: remove entryslide__consent-outer-container

### DIFF
--- a/client/components/Scenario/EntrySlide.css
+++ b/client/components/Scenario/EntrySlide.css
@@ -3,10 +3,6 @@
     overflow-y: auto;
 }
 
-.entryslide__consent-outer-container {
-    max-height: 43vh;
-}
-
 .entryslide__consent-inner-container {
     max-height: 16rem;
     overflow-y: auto;

--- a/client/components/Scenario/EntrySlide.jsx
+++ b/client/components/Scenario/EntrySlide.jsx
@@ -69,7 +69,6 @@ class EntrySlide extends React.Component {
                             size="large"
                             color="yellow"
                             header="Consent Agreement"
-                            className="entryslide__consent-outer-container"
                             content={
                                 <div>
                                     <p


### PR DESCRIPTION
I just determined that this was actually unnecessary. 