### PR TITLE
Add filtering to homepage for categories, author, user completed moments

### DIFF
--- a/client/routes/Navigation.jsx
+++ b/client/routes/Navigation.jsx
@@ -53,6 +53,7 @@ const Navigation = () => {
             );
         }
     );
+    const { username } = Session.getSession();
 
     return (
         <React.Fragment>
@@ -82,6 +83,26 @@ const Navigation = () => {
                             text={<NavLink to="/">Moments</NavLink>}
                         >
                             <Dropdown.Menu>
+                                {Session.isSessionActive() && (
+                                    <React.Fragment>
+                                        <ConfirmAuth requiredPermission="create_scenario">
+                                            <Dropdown.Item>
+                                                <NavLink
+                                                    to={{
+                                                        pathname: `/author/${username}`
+                                                    }}
+                                                >
+                                                    My Moments
+                                                </NavLink>
+                                            </Dropdown.Item>
+                                        </ConfirmAuth>
+                                        <Dropdown.Item>
+                                            <NavLink to="/continue">
+                                                Continue Moments
+                                            </NavLink>
+                                        </Dropdown.Item>
+                                    </React.Fragment>
+                                )}
                                 <Dropdown.Item>
                                     <NavLink to="/official">Official</NavLink>
                                 </Dropdown.Item>

--- a/client/routes/RouteComponents.jsx
+++ b/client/routes/RouteComponents.jsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { Route } from 'react-router-dom';
+import PropTypes from 'prop-types';
+
+import Editor from '@client/components/Editor';
+import Login from '@client/components/Login';
+import LoginRoutePromptModal from '@client/components/Login/LoginRoutePromptModal';
+import ScenariosList from '@client/components/ScenariosList';
+
+import Session from '@client/util/session';
+
+/**
+ * Special case components for solving routing issues. Component state
+ * doesn't update when navigating to exact same component.
+ */
+
+export const NewScenario = props => {
+    return <Editor {...props} isNewScenario={true} />;
+};
+
+export const ScenariosListAll = props => {
+    return <ScenariosList {...props} category="all" />;
+};
+
+export const ScenariosListAuthor = props => {
+    return <ScenariosList {...props} category="author" />;
+};
+
+export const ScenariosListContinue = props => {
+    return <ScenariosList {...props} category="continue" />;
+};
+
+export const ScenariosListCommunity = props => {
+    return <ScenariosList {...props} category="community" />;
+};
+
+export const ScenariosListOfficial = props => {
+    return <ScenariosList {...props} category="official" />;
+};
+
+export const Logout = props => {
+    return <Login {...props} mode="logout" />;
+};
+
+export const InterceptAnonymizableRoute = ({ children, ...rest }) => {
+    return (
+        <Route
+            {...rest}
+            render={props => {
+                return Session.isSessionActive() ? (
+                    children
+                ) : (
+                    <LoginRoutePromptModal {...props} />
+                );
+            }}
+        />
+    );
+};
+
+InterceptAnonymizableRoute.propTypes = {
+    children: PropTypes.oneOfType([
+        PropTypes.arrayOf(PropTypes.node),
+        PropTypes.node
+    ]).isRequired
+};

--- a/client/routes/Routes.jsx
+++ b/client/routes/Routes.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Route, Switch } from 'react-router-dom';
-import PropTypes from 'prop-types';
+
 import AccountAdmin from '@client/components/AccountAdmin';
 import Cohort from '@client/components/Facilitator/Components/Cohorts/Cohort';
 import ConfirmAuth from '@client/components/ConfirmAuth';
@@ -8,52 +8,32 @@ import CreateAccount from '@client/components/CreateAccount';
 import CreateAnonymousAccount from '@client/components/CreateAccount/CreateAnonymousAccount';
 import Editor from '@client/components/Editor';
 import Facilitator from '@client/components/Facilitator';
+import { InterceptAnonymizableRoute } from './RouteComponents';
 import Login from '@client/components/Login';
-import LoginRoutePromptModal from '@client/components/Login/LoginRoutePromptModal';
+import { Logout } from './RouteComponents';
+import { NewScenario } from './RouteComponents';
 import Researcher from '@client/components/Researcher';
 import Run from '@client/components/Run';
-import ScenariosList from '@client/components/ScenariosList';
-
-import Session from '@client/util/session';
-
-// Special case component for solving new scenario routing issue.
-// Previously the route wouldn't update to the same Editor component.
-const NewScenario = props => {
-    return <Editor {...props} isNewScenario={true} />;
-};
-
-const Logout = props => {
-    return <Login {...props} mode="logout" />;
-};
-
-const InterceptAnonymizableRoute = ({ children, ...rest }) => {
-    return (
-        <Route
-            {...rest}
-            render={props => {
-                return Session.isSessionActive() ? (
-                    children
-                ) : (
-                    <LoginRoutePromptModal {...props} />
-                );
-            }}
-        />
-    );
-};
-
-InterceptAnonymizableRoute.propTypes = {
-    children: PropTypes.oneOfType([
-        PropTypes.arrayOf(PropTypes.node),
-        PropTypes.node
-    ]).isRequired
-};
+import {
+    ScenariosListAll,
+    ScenariosListAuthor,
+    ScenariosListCommunity,
+    ScenariosListContinue,
+    ScenariosListOfficial
+} from './RouteComponents';
 
 const Routes = () => {
     return (
         <Switch>
-            <Route exact path="/" component={ScenariosList} />
-            <Route exact path="/official" component={ScenariosList} />
-            <Route exact path="/community" component={ScenariosList} />
+            <Route exact path="/" component={ScenariosListAll} />
+            <Route
+                exact
+                path="/author/:username"
+                component={ScenariosListAuthor}
+            />
+            <Route exact path="/continue" component={ScenariosListContinue} />
+            <Route exact path="/official" component={ScenariosListOfficial} />
+            <Route exact path="/community" component={ScenariosListCommunity} />
             <InterceptAnonymizableRoute path="/run/:scenarioId/:activeSlideIndex">
                 <Route component={Run} />
             </InterceptAnonymizableRoute>

--- a/server/service/scenarios/db.js
+++ b/server/service/scenarios/db.js
@@ -225,6 +225,20 @@ async function getScenarioResearchData(scenarioId) {
     return result.rows;
 }
 
+async function getScenarioByRun(userId) {
+    const result = await query(sql`
+        SELECT DISTINCT * FROM scenario
+        WHERE id IN
+        (
+            SELECT scenario_id
+            FROM run
+            WHERE user_id = ${userId}
+        );
+    `);
+
+    return result.rows;
+}
+
 // Scenario
 exports.addScenario = addScenario;
 exports.setScenario = setScenario;
@@ -233,6 +247,7 @@ exports.deleteScenario = deleteScenario;
 exports.softDeleteScenario = softDeleteScenario;
 exports.getAllScenarios = getAllScenarios;
 exports.getScenarioResearchData = getScenarioResearchData;
+exports.getScenarioByRun = getScenarioByRun;
 
 // Scenario Consent
 exports.addConsent = addConsent;

--- a/server/service/scenarios/endpoints.js
+++ b/server/service/scenarios/endpoints.js
@@ -245,3 +245,9 @@ exports.getScenarioDataResearcher = asyncMiddleware(async function(req, res) {
     const data = await db.getScenarioResearchData(scenarioId);
     res.send({ data });
 });
+
+exports.getScenarioByRun = asyncMiddleware(async function(req, res) {
+    const userId = req.session.user.id;
+    const scenarios = await db.getScenarioByRun(userId);
+    res.send({ scenarios, status: 200 });
+});

--- a/server/service/scenarios/index.js
+++ b/server/service/scenarios/index.js
@@ -11,11 +11,13 @@ const {
     getAllScenarios,
     getScenario,
     getScenarioDataResearcher,
+    getScenarioByRun,
     setScenario,
     softDeleteScenario
 } = require('./endpoints.js');
 
 router.get('/', getAllScenarios);
+router.get('/run', getScenarioByRun);
 router.get('/:scenario_id', [lookupScenario(), getScenario]);
 
 // TODO: there should be a middleware here to check for permissions


### PR DESCRIPTION
@rwaldron @isaacdurazo this PR adds a filtering capability to the home page using a dropdown in the main nav. These are the current options:

<img width="667" alt="Screen Shot 2019-12-06 at 9 37 42 AM" src="https://user-images.githubusercontent.com/7991694/70330718-16d5b580-180c-11ea-8ac6-a24a9b3aaf59.png">

And the asana task is here for checking what users should see when: https://app.asana.com/0/1127815256483386/1150836802035131

Steps for testing:
- Start as a logged out user. You should see the drop down options for "Official" and "Community" moments
- Log in as a participant user. You should see the same options plus "Completed Moments", which shows all the moments your user has run.
- Log in as a researcher, facilitator, admin or super admin. You will see the above plus "My Moments" which are the moments your user has authored.

My proposed code changes:
- Expand the category filtering logic in `ScenariosList/index` to account for the four categories above. 
- Add filtering options to the nav based on whether you're logged in and/or have the right permissions levels
- Move our component variations to a separate file and add more for filtering different `ScenarioList` components
- Add routes for the scenarios list components
- Add an endpoint that gets all the scenarios that have associated with runs for the logged in user. This is helpful for getting moments completed (or at least started) by the user

Let me know if you have any questions!