### PR TITLE
Remove 'Data Export' from the nav

### DIFF
--- a/client/routes/Navigation.jsx
+++ b/client/routes/Navigation.jsx
@@ -21,11 +21,6 @@ const restrictedNav = [
         permission: 'view_run_data'
     },
     {
-        text: 'Data Export',
-        path: '/cohorts',
-        permission: 'view_run_data'
-    },
-    {
         text: 'Account Administration',
         path: '/account-administration',
         permission: 'edit_permissions'


### PR DESCRIPTION
Short and sweet! This removes the "Data Export" menu item from the main nav. 

Steps to test:
- load home page and confirm "Data Export" isn't in the nav
- Click "Cohorts Management" and confirm it's still available