### PR TITLE
Bug: Clear responses from localstorage once they are submitted.

### DIFF
--- a/client/actions/response.js
+++ b/client/actions/response.js
@@ -36,6 +36,10 @@ export const setResponses = (id, responses) => async dispatch => {
                 },
                 body: JSON.stringify(body)
             });
+
+            if (localStorage[name]) {
+                localStorage.removeItem(name);
+            }
         }
 
         dispatch({ type: SET_RESPONSES_SUCCESS, responses });


### PR DESCRIPTION
We don't responses to stick around in client side storage after they are submitted. Doing so will have a bizarre outcome: you will see them the next time you do a run of that scenario.