### PR TITLE
Add checkmark icon to official scenarios

### DIFF
--- a/client/components/ScenariosList/ScenarioCard.jsx
+++ b/client/components/ScenariosList/ScenarioCard.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { Button, Card } from 'semantic-ui-react';
+import { Button, Card, Icon } from 'semantic-ui-react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { getScenarios } from '@client/actions/scenario';
@@ -47,7 +47,17 @@ class ScenarioCard extends React.Component {
         const { onClick } = this;
         const { isLoggedIn } = this.props;
         const { scenario } = this.state;
-        const { id, title, description, deleted_at, user_is_author } = scenario;
+        const {
+            categories,
+            id,
+            description,
+            deleted_at,
+            title,
+            user_is_author
+        } = scenario;
+        const officialCheckmark = categories.includes('official') ? (
+            <Icon name="check" />
+        ) : null;
 
         return deleted_at ? (
             <ConfirmAuth
@@ -64,7 +74,9 @@ class ScenarioCard extends React.Component {
         ) : (
             <Card className="scenario__entry" key={id}>
                 <Card.Content>
-                    <Card.Header>{title}</Card.Header>
+                    <Card.Header>
+                        {title} {officialCheckmark}
+                    </Card.Header>
                     <Card.Description className="scenario__entry--description">
                         {description}
                     </Card.Description>


### PR DESCRIPTION
Proposed changes:
- Check if a moment's categories include the string "official"
- Add a checkmark icon if so

<img width="658" alt="Screen Shot 2019-12-09 at 8 19 26 AM" src="https://user-images.githubusercontent.com/7991694/70438822-a8d3fd00-1a5c-11ea-94d6-9e1d3a4a5ef2.png">

Steps to test:
- Confirm listings of scenarios have the checkmark if they're official 
- Confirm they don't if they're not