### PR TITLE
Bug: Display "prompt" in AudioResponse Display fallback

### DIFF
--- a/client/components/Slide/Components/AudioResponse/Display.jsx
+++ b/client/components/Slide/Components/AudioResponse/Display.jsx
@@ -175,7 +175,7 @@ class Display extends Component {
             required && <PromptRequiredLabel fulfilled={fulfilled} />
         ) : (
             <React.Fragment>
-                Type your response here:{' '}
+                {prompt}{' '}
                 {required && <PromptRequiredLabel fulfilled={fulfilled} />}
             </React.Fragment>
         );
@@ -224,6 +224,7 @@ class Display extends Component {
         ) : (
             <Segment>
                 <Header as="h3">{header}</Header>
+
                 <Form>
                     <Form.TextArea
                         name={responseId}

--- a/client/components/Slide/Components/AudioResponse/index.js
+++ b/client/components/Slide/Components/AudioResponse/index.js
@@ -1,7 +1,7 @@
 import { type } from './type';
 export { type };
 export const defaultValue = ({ responseId }) => ({
-    prompt: 'Click then speak',
+    prompt: 'Record your response',
     recallId: '',
     required: true,
     responseId,


### PR DESCRIPTION
Fallback view: 

Before: 
![image](https://user-images.githubusercontent.com/27985/70449710-716f4b80-1a70-11ea-9d3a-4cd15a54c272.png)

After: 
![image](https://user-images.githubusercontent.com/27985/70449661-5dc3e500-1a70-11ea-894e-bd3b30004b84.png)

-----------------

Audio Prompt reference: 

![image](https://user-images.githubusercontent.com/27985/70449738-83e98500-1a70-11ea-941f-6274dbdf85ab.png)
