### PR TITLE
Dependency: use "local-storage-fallback" instead of directly using "localStorage"

### DIFF
--- a/client/actions/response.js
+++ b/client/actions/response.js
@@ -38,8 +38,8 @@ export const setResponses = (id, responses) => async dispatch => {
                 body: JSON.stringify(body)
             });
 
-            if (storage[name]) {
-                storage.removeItem(name);
+            if (storage[`${id}-${name}`]) {
+                storage.removeItem(`${id}-${name}`);
             }
         }
 

--- a/client/actions/response.js
+++ b/client/actions/response.js
@@ -1,3 +1,4 @@
+import storage from 'local-storage-fallback';
 import {
     GET_RESPONSE,
     GET_RESPONSE_SUCCESS,
@@ -37,8 +38,8 @@ export const setResponses = (id, responses) => async dispatch => {
                 body: JSON.stringify(body)
             });
 
-            if (localStorage[name]) {
-                localStorage.removeItem(name);
+            if (storage[name]) {
+                storage.removeItem(name);
             }
         }
 

--- a/client/components/Facilitator/Components/Cohorts/Cohort.jsx
+++ b/client/components/Facilitator/Components/Cohorts/Cohort.jsx
@@ -4,6 +4,7 @@ import { withRouter } from 'react-router';
 import PropTypes from 'prop-types';
 import { Icon, Menu, Popup, Segment } from 'semantic-ui-react';
 import copy from 'copy-text-to-clipboard';
+import storage from 'local-storage-fallback';
 import {
     getCohort,
     setCohort,
@@ -30,9 +31,9 @@ export class Cohort extends React.Component {
 
         // This is a hack to get through the testing on Monday.
         {
-            let localCohort = localStorage.getItem('cohort');
+            let localCohort = storage.getItem('cohort');
             if (id && localCohort !== id) {
-                localStorage.setItem('cohort', id);
+                storage.setItem('cohort', id);
             } else {
                 if (localCohort !== null) {
                     id = Number(localCohort);

--- a/client/components/Scenario/ContentSlide.jsx
+++ b/client/components/Scenario/ContentSlide.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { Button, Card, Icon, Popup } from 'semantic-ui-react';
+import storage from 'local-storage-fallback';
 
 import SlideComponentsList from '@components/SlideComponentsList';
 
@@ -101,7 +102,7 @@ class ContentSlide extends React.Component {
 
         if (!data.isFulfilled) {
             this.props.onResponseChange(event, data);
-            localStorage.setItem(name, JSON.stringify(data));
+            storage.setItem(name, JSON.stringify(data));
             this.setState({
                 skipButton: 'Choose to skip',
                 skipOrKeep: 'skip'

--- a/client/components/Scenario/ContentSlide.jsx
+++ b/client/components/Scenario/ContentSlide.jsx
@@ -83,6 +83,8 @@ class ContentSlide extends React.Component {
             return null;
         }
 
+        const { run } = this.props;
+
         // If we have a response change for a responseId that
         // was marked required, and the value isn't empty,
         // then it can be removed from the list.
@@ -102,7 +104,7 @@ class ContentSlide extends React.Component {
 
         if (!data.isFulfilled) {
             this.props.onResponseChange(event, data);
-            storage.setItem(name, JSON.stringify(data));
+            storage.setItem(`${run.id}-${name}`, JSON.stringify(data));
             this.setState({
                 skipButton: 'Choose to skip',
                 skipOrKeep: 'skip'

--- a/client/components/SlideComponentsList/index.jsx
+++ b/client/components/SlideComponentsList/index.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import * as Components from '@components/Slide/Components';
+import storage from 'local-storage-fallback';
 
 const SlideComponentsList = ({
     asSVG = false,
@@ -57,7 +58,7 @@ const SlideComponentsList = ({
             const { Display } = Components[type];
             const persisted = JSON.parse(
                 run && responseId
-                    ? localStorage.getItem(responseId) || emptyValue
+                    ? storage.getItem(responseId) || emptyValue
                     : emptyValue
             );
             return (

--- a/client/components/SlideComponentsList/index.jsx
+++ b/client/components/SlideComponentsList/index.jsx
@@ -58,7 +58,7 @@ const SlideComponentsList = ({
             const { Display } = Components[type];
             const persisted = JSON.parse(
                 run && responseId
-                    ? storage.getItem(responseId) || emptyValue
+                    ? storage.getItem(`${run.id}-${responseId}`) || emptyValue
                     : emptyValue
             );
             return (

--- a/client/package.json
+++ b/client/package.json
@@ -42,6 +42,7 @@
     "eslint-plugin-prettier": "^3.1.0",
     "eslint-plugin-react": "^7.14.3",
     "json2csv": "^4.5.4",
+    "local-storage-fallback": "^4.1.1",
     "lodash": "^4.17.15",
     "mic-recorder-to-mp3": "^2.2.1",
     "nib-converter": "^2.2.5",

--- a/client/util/session.js
+++ b/client/util/session.js
@@ -1,3 +1,5 @@
+import storage from 'local-storage-fallback';
+
 const TIMEOUT = 1000 * 60 * 60;
 
 const getSession = () => {
@@ -5,7 +7,7 @@ const getSession = () => {
         timestamp = Date.now(),
         username = '',
         permissions = []
-    } = JSON.parse(localStorage.getItem('session')) || {
+    } = JSON.parse(storage.getItem('session')) || {
         timestamp: '',
         username: '',
         permissions: []
@@ -29,11 +31,11 @@ const isLoggedIn = () => {
 };
 
 const destroy = () => {
-    localStorage.removeItem('session');
+    storage.removeItem('session');
 };
 
 const create = session => {
-    localStorage.setItem('session', JSON.stringify(session));
+    storage.setItem('session', JSON.stringify(session));
 };
 
 export default {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3928,6 +3928,11 @@ cookie@0.4.0:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
   integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
 
+cookie@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
+  integrity sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=
+
 copy-concurrently@^1.0.0:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/copy-concurrently/-/copy-concurrently-1.0.5.tgz#92297398cae34937fcafd6ec8139c18051f0b5e0"
@@ -7757,6 +7762,13 @@ loader-utils@1.2.3, loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.
     big.js "^5.2.2"
     emojis-list "^2.0.0"
     json5 "^1.0.1"
+
+local-storage-fallback@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/local-storage-fallback/-/local-storage-fallback-4.1.1.tgz#6dc964635c8e9ab6d522d7d88538f465b62bd161"
+  integrity sha512-Ka4rem1FOgvIaPMokxXTP8DgW8gjfAQSdJC8TGrplDug7vh3b0PZnY/9euG3O3cIGAvJLp33mMU6MJ13x6S+Pw==
+  dependencies:
+    cookie "^0.3.1"
 
 locate-path@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This will make our use of local persistence a bit more robust.


Test 1: 
1. Run a scenario that has a text prompt, type something into it, but don't hit submit, then refresh the page. Is it still there?
2. Hit submit, move on and complete/finish the scenario 
3. Re run the scenario, when you arrive at the text prompt, is your old entry there or is it clear?

Test 2: 
1. Go to a cohort as a participant, does "My Cohort" persist the cohort you were invited to?

Test 3: 
1. When you're logged in, do you stay logged in across all pages?