### PR TITLE
Run: capture and save referrer query params

### DIFF
--- a/client/components/CreateAccount/CreateAnonymousAccount.jsx
+++ b/client/components/CreateAccount/CreateAnonymousAccount.jsx
@@ -87,7 +87,7 @@ class CreateAnonymousAccount extends Component {
 
             // Step outside of react to force a real reload
             // after signup and session create
-            location.href = from ? from.pathname : '/';
+            location.href = from ? `${from.pathname}${from.search}` : '/';
         }
     }
 

--- a/client/components/CreateAccount/index.jsx
+++ b/client/components/CreateAccount/index.jsx
@@ -99,7 +99,7 @@ class CreateAccount extends Component {
 
             // Step outside of react to force a real reload
             // after signup and session create
-            location.href = from ? from.pathname : '/';
+            location.href = from ? `${from.pathname}${from.search}` : '/';
         }
     }
 

--- a/client/components/Facilitator/Components/Cohorts/Cohort.jsx
+++ b/client/components/Facilitator/Components/Cohorts/Cohort.jsx
@@ -21,14 +21,19 @@ export class Cohort extends React.Component {
     constructor(props) {
         super(props);
 
+        const { location, match } = this.props;
+
         let {
             params: { id }
-        } = this.props.match;
+        } = match;
 
         if (!id && this.props.id) {
             id = this.props.id;
         }
 
+        if (location && location.search) {
+            storage.setItem(`referrer_params`, location.search);
+        }
         // This is a hack to get through the testing on Monday.
         {
             let localCohort = storage.getItem('cohort');
@@ -50,7 +55,6 @@ export class Cohort extends React.Component {
         };
 
         this.onClick = this.onClick.bind(this);
-        // TODO: This will be used in a follow up changeset
         this.onDataTableClick = this.onDataTableClick.bind(this);
         this.onTabClick = this.onTabClick.bind(this);
     }
@@ -285,6 +289,11 @@ Cohort.propTypes = {
         push: PropTypes.func.isRequired
     }).isRequired,
     id: PropTypes.any,
+    location: PropTypes.shape({
+        pathname: PropTypes.string,
+        search: PropTypes.string,
+        state: PropTypes.object
+    }),
     match: PropTypes.shape({
         path: PropTypes.string,
         params: PropTypes.shape({

--- a/client/components/Login/index.jsx
+++ b/client/components/Login/index.jsx
@@ -93,7 +93,7 @@ class Login extends Component {
 
             // Step outside of react to force a real reload
             // after login and session create
-            location.href = from ? from.pathname : '/';
+            location.href = from ? `${from.pathname}${from.search}` : '/';
         }
     }
 

--- a/client/components/Scenario/index.jsx
+++ b/client/components/Scenario/index.jsx
@@ -32,9 +32,10 @@ class Scenario extends Component {
         this.getScenarioSlides();
 
         if (this.isScenarioRun) {
-            const pathToSlide = `${baseurl}/slide/${activeSlideIndex}`;
+            const { pathname, search } = location;
+            const pathToSlide = `${baseurl}/slide/${activeSlideIndex}${search}`;
 
-            if (location.pathname !== pathToSlide) {
+            if (pathname !== pathToSlide) {
                 history.push(pathToSlide);
             }
         }
@@ -194,6 +195,7 @@ Scenario.propTypes = {
     baseurl: PropTypes.string,
     location: PropTypes.shape({
         pathname: PropTypes.string,
+        search: PropTypes.string,
         state: PropTypes.object
     }),
     match: PropTypes.shape({

--- a/client/package.json
+++ b/client/package.json
@@ -50,7 +50,7 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^1.18.2",
     "prop-types": "^15.7.2",
-    "query-string": "^6.8.3",
+    "query-string": "^6.9.0",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
     "react-hot-loader": "^4.12.11",

--- a/server/migrations/20191211151235-inbound-url-params-store-arbitrary-url-params-with-run-responses.js
+++ b/server/migrations/20191211151235-inbound-url-params-store-arbitrary-url-params-with-run-responses.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const sqlFile = require('./helpers/sql-file')(__filename);
+exports.up = function(db) {
+    return db.runSql(sqlFile.up);
+};
+exports.down = function(db) {
+    return db.runSql(sqlFile.down);
+};
+exports._meta = {
+    version: 1
+};

--- a/server/migrations/sql/20191211151235-inbound-url-params-store-arbitrary-url-params-with-run-responses.sql
+++ b/server/migrations/sql/20191211151235-inbound-url-params-store-arbitrary-url-params-with-run-responses.sql
@@ -1,0 +1,7 @@
+ALTER TABLE run
+    ADD COLUMN referrer_params JSONB;
+-- Up above
+---
+-- Down below
+ALTER TABLE run
+    DROP COLUMN referrer_params;

--- a/server/service/runs/endpoints.js
+++ b/server/service/runs/endpoints.js
@@ -67,6 +67,11 @@ async function revokeConsentForRunAsync(req, res) {
     res.json({ status: 200, run });
 }
 
+async function getReferrerParamsAsync(req, res) {
+    const { referrer_params } = await runForRequest(req);
+    res.json({ status: 200, referrer_params });
+}
+
 async function finishRunAsync(req, res) {
     const { id } = await runForRequest(req);
     res.json(await db.finishRun(id));
@@ -76,5 +81,6 @@ exports.finishRun = asyncMiddleware(finishRunAsync);
 exports.getResponse = asyncMiddleware(getResponseAsync);
 exports.newOrExistingRun = asyncMiddleware(newOrExistingRunAsync);
 exports.revokeConsentForRun = asyncMiddleware(revokeConsentForRunAsync);
+exports.getReferrerParams = asyncMiddleware(getReferrerParamsAsync);
 exports.updateRun = asyncMiddleware(updateRunAsync);
 exports.upsertResponse = asyncMiddleware(upsertResponseAsync);

--- a/server/service/runs/index.js
+++ b/server/service/runs/index.js
@@ -5,6 +5,7 @@ const { requireUserForRun } = require('./middleware');
 const {
     finishRun,
     getResponse,
+    getReferrerParams,
     newOrExistingRun,
     revokeConsentForRun,
     updateRun,
@@ -35,5 +36,6 @@ runs.post('/:run_id/response/:response_id', [
 ]);
 
 runs.get('/:run_id/response/:response_id', [requireUserForRun, getResponse]);
+runs.get('/:run_id/referrer-params', [requireUserForRun, getReferrerParams]);
 
 module.exports = runs;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9891,10 +9891,10 @@ query-string@^4.1.0:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
-query-string@^6.8.3:
-  version "6.8.3"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.8.3.tgz#fd9fb7ffb068b79062b43383685611ee47777d4b"
-  integrity sha512-llcxWccnyaWlODe7A9hRjkvdCKamEKTh+wH8ITdTc3OhchaqUZteiSCX/2ablWHVrkVIe04dntnaZJ7BdyW0lQ==
+query-string@^6.9.0:
+  version "6.9.0"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.9.0.tgz#1c3b727c370cf00f177c99f328fda2108f8fa3dd"
+  integrity sha512-KG4bhCFYapExLsUHrFt+kQVEegF2agm4cpF/VNc6pZVthIfCc/GK8t8VyNIE3nyXG9DK3Tf2EGkxjR6/uRdYsA==
   dependencies:
     decode-uri-component "^0.2.0"
     split-on-first "^1.0.0"


### PR DESCRIPTION
This depends on both "Create Account" and the "local-storage-fallback" update 

(Pick a scenario id to reuse for all of these)
Let COHORT_ID be your preferred cohort's id
Let SCENARIO_ID be your preferred scenario's id

Test 1: 

- Open http://localhost:3000/run/SCENARIO_ID?a=1&b=2
- Use a postrgres tool to run: 
    ```sql
    SELECT * FROM run WHERE referrer_params IS NOT NULL;
    ```
- If the run has `{a:1,b:2}` stored, then it worked.
- Repeat by starting from logged out and being an anonymous user


Test 2: 

- Open http://localhost:3000/cohort/COHORT_ID/run/SCENARIO_ID?a=1&b=2
- Use a postrgres tool to run: 
    ```sql
    SELECT * FROM run WHERE referrer_params IS NOT NULL;
    ```
- If the run has `{a:1,b:2}` stored, then it worked.
- Repeat by starting from logged out and being an anonymous user

Test 3: 

- Open http://localhost:3000/cohort/COHORT_ID?a=1&b=2
- Navigate through to a scenario to run and run it. 
- Use a postrgres tool to run: 
    ```sql
    SELECT * FROM run WHERE referrer_params IS NOT NULL;
    ```
- If the run has `{a:1,b:2}` stored, then it worked.
- Repeat by starting from logged out and being an anonymous user