### PR TITLE
Run: don't let scenario slide text extend beyond card boundary for very long text

### DIFF
--- a/client/components/Scenario/Scenario.css
+++ b/client/components/Scenario/Scenario.css
@@ -5,7 +5,7 @@
 
 .ui.card.scenario__card--run {
     width: 93vw;
-    height: 85vh;
+    min-height: 85vh;
     max-width: 500px;
     margin-top: 2vh;
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/27985/70650765-a967c180-1c1d-11ea-8a6b-5b3bed0df0db.png)
