### PR TITLE
Run: don't show skip button on slides that contain required prompts; fix next slide tip text

### DIFF
--- a/client/components/Scenario/ContentSlide.jsx
+++ b/client/components/Scenario/ContentSlide.jsx
@@ -115,7 +115,7 @@ class ContentSlide extends React.Component {
     }
 
     render() {
-        const { pending, skipButton, skipOrKeep } = this.state;
+        const { pending, required, skipButton, skipOrKeep } = this.state;
         const {
             isLastSlide,
             onClickNext,
@@ -139,6 +139,7 @@ class ContentSlide extends React.Component {
             </React.Fragment>
         );
 
+        const hasRequiredFields = !!required.length;
         const color = pending.length ? 'red' : 'green';
         const content = pending.length
             ? awaitingRequiredPrompts
@@ -150,7 +151,10 @@ class ContentSlide extends React.Component {
             content,
             onClick
         };
-        let fwdButtonTip = 'Submit response and go to next slide';
+        let fwdButtonTip = hasPrompt
+            ? 'Submit response and go to next slide'
+            : 'Go to the next slide';
+
         let skipButtonTip =
             skipOrKeep === 'skip'
                 ? 'Skip these prompts and go to next slide'
@@ -165,8 +169,8 @@ class ContentSlide extends React.Component {
         if (isLastSlide) {
             skipButtonContent =
                 skipOrKeep === 'skip' ? 'Skip and finish' : 'Keep and finish';
-            skipButtonTip = skipButtonTip.replace('go to next slide', 'finish');
-            fwdButtonTip = fwdButtonTip.replace('go to next slide', 'finish');
+            skipButtonTip = 'Skip these prompts and finish';
+            fwdButtonTip = 'Finish';
         }
 
         return (
@@ -198,7 +202,7 @@ class ContentSlide extends React.Component {
                             content={fwdButtonTip}
                             trigger={<Button {...fwdButtonProps} />}
                         />
-                        {hasPrompt && (
+                        {hasPrompt && !hasRequiredFields && (
                             <React.Fragment>
                                 <Button.Or />
                                 <Popup


### PR DESCRIPTION
The "Skip" Button is now gone from slides that contain any required inputs: 

![image](https://user-images.githubusercontent.com/27985/70653964-70cae680-1c23-11ea-860c-437708668fa1.png)

![image](https://user-images.githubusercontent.com/27985/70653984-77595e00-1c23-11ea-8521-90fe5559f8b6.png)

The "Skip" button is still present on slides with inputs that are not marked "required": 

![image](https://user-images.githubusercontent.com/27985/70654031-89d39780-1c23-11ea-9287-d56493d58889.png)


The "Next" button doesn't say "Submit" when there are no things to "submit"

![image](https://user-images.githubusercontent.com/27985/70654063-9821b380-1c23-11ea-879c-9371e3d1ece7.png)

