### PR TITLE
Adjust load test

### DIFF
--- a/server/migrations/20191211193451-cascade-user-deletion.js
+++ b/server/migrations/20191211193451-cascade-user-deletion.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const sqlFile = require('./helpers/sql-file')(__filename);
+exports.up = function(db) {
+    return db.runSql(sqlFile.up);
+};
+exports.down = function(db) {
+    return db.runSql(sqlFile.down);
+};
+exports._meta = {
+    version: 1
+};

--- a/server/migrations/sql/20191211193451-cascade-user-deletion.sql
+++ b/server/migrations/sql/20191211193451-cascade-user-deletion.sql
@@ -1,0 +1,18 @@
+
+ALTER TABLE user_role
+DROP CONSTRAINT "roles_user_id_fkey";
+
+ALTER TABLE user_role
+ADD CONSTRAINT "roles_user_id_fkey"
+    FOREIGN KEY(user_id)
+    REFERENCES users(id)
+    ON DELETE CASCADE;
+---
+
+ALTER TABLE user_role
+DROP CONSTRAINT "roles_user_id_fkey";
+
+ALTER TABLE user_role
+ADD CONSTRAINT "roles_user_id_fkey"
+    FOREIGN KEY(user_id)
+    REFERENCES users(id);

--- a/test/load/participant-scenario-run.yml
+++ b/test/load/participant-scenario-run.yml
@@ -14,12 +14,12 @@ config:
           - "scenarioId"
   phases:
     - duration: 60
-      arrivalRate: 5
+      arrivalRate: 1
     - duration: 120
-      arrivalRate: 5
-      rampTo: 20
+      arrivalRate: 1
+      rampTo: 3
     - duration: 600
-      arrivalRate: 30
+      arrivalRate: 1
 scenarios:
   - name: "Get scenarios on the front end"
     flow:


### PR DESCRIPTION
Proposed changes in this PR:
- Add a migration to change the foreign key constraint on `user_role` table to allow us to delete users. This will be important for cleaning up after the load test.
- Reduce the number of users that will be simulated in the load test. Now it's closer to 1,000.

Test steps:
- Run migration locally and then run a SQL command to delete a user you don't need in your local database