### PR TITLE
Cohort: scenario list view needs to hide description to make room for scenario title & button

### DIFF
--- a/client/components/Facilitator/Components/Cohorts/Cohort.css
+++ b/client/components/Facilitator/Components/Cohorts/Cohort.css
@@ -51,6 +51,12 @@
     text-overflow: ellipsis;
 }
 
+@media only screen and (max-width: 767px) {
+    .cohort__table-cell--description {
+        display: none !important;
+    }
+}
+
 .cohort__table--search {
     margin-left: 0.5rem !important;
 }

--- a/client/components/Facilitator/Components/Cohorts/CohortScenarios.jsx
+++ b/client/components/Facilitator/Components/Cohorts/CohortScenarios.jsx
@@ -187,6 +187,7 @@ export class CohortScenarios extends React.Component {
                     role="grid"
                     aria-labelledby="header"
                     className="cohort__table--constraints"
+                    unstackable
                 >
                     <Table.Header className="cohort__table-thead-tbody-tr">
                         <Table.Row>


### PR DESCRIPTION
https://app.asana.com/0/1127815256483386/1130681121061059/f

Before: 

![image](https://user-images.githubusercontent.com/27985/70658074-39f8ce80-1c2b-11ea-8ef7-1915d4d88345.png)

The description isn't clickable, so we can just hide and only show the scenario title on mobile. 

![image](https://user-images.githubusercontent.com/27985/70658117-54cb4300-1c2b-11ea-8f98-2680ceac32b8.png)
