### PR TITLE
Editor: Add "header" field to all "prompt" components

### DIFF
--- a/client/components/Slide/Components/AudioResponse/Editor.jsx
+++ b/client/components/Slide/Components/AudioResponse/Editor.jsx
@@ -2,11 +2,11 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import {
     Accordion,
-    Checkbox,
     Container,
     Form,
     Icon,
     Input,
+    Label,
     Message,
     Popup
 } from 'semantic-ui-react';
@@ -18,35 +18,44 @@ import '@components/Slide/SlideEditor/SlideEditor.css';
 class AudioResponseEditor extends Component {
     constructor(props) {
         super(props);
-        const { prompt, recallId = '', required, responseId } = props.value;
+        const {
+            header = '',
+            prompt = '',
+            recallId = '',
+            required,
+            responseId
+        } = props.value;
         this.state = {
             activeIndex: recallId ? 0 : -1,
+            header,
             prompt,
             recallId,
             required,
             responseId
         };
-        this.onPromptChange = this.onPromptChange.bind(this);
-        this.onRequirementChange = this.onRequirementChange.bind(this);
+        this.onChange = this.onChange.bind(this);
         this.onRecallChange = this.onRecallChange.bind(this);
         this.toggleOptional = this.toggleOptional.bind(this);
     }
 
     updateState() {
-        const { prompt, recallId, required, responseId } = this.state;
-        this.props.onChange({ prompt, recallId, required, responseId, type });
+        const { header, prompt, recallId, required, responseId } = this.state;
+        this.props.onChange({
+            header,
+            prompt,
+            recallId,
+            required,
+            responseId,
+            type
+        });
     }
 
-    onPromptChange(event, { value }) {
-        this.setState({ prompt: value }, this.updateState);
+    onChange(event, { name, value }) {
+        this.setState({ [name]: value }, this.updateState);
     }
 
     onRecallChange({ recallId }) {
         this.setState({ recallId }, this.updateState);
-    }
-
-    onRequirementChange(event, { checked }) {
-        this.setState({ required: checked }, this.updateState);
     }
 
     toggleOptional(event, { index }) {
@@ -57,14 +66,10 @@ class AudioResponseEditor extends Component {
     }
 
     render() {
-        const { activeIndex, prompt, recallId, required } = this.state;
+        const { activeIndex, header, prompt, recallId } = this.state;
         const { scenarioId } = this.props;
-        const {
-            onPromptChange,
-            onRecallChange,
-            onRequirementChange,
-            toggleOptional
-        } = this;
+        const { onChange, onRecallChange, toggleOptional } = this;
+
         return (
             <Form>
                 <Container fluid>
@@ -92,22 +97,38 @@ class AudioResponseEditor extends Component {
                     <Popup
                         content="This is the label that will appear on the Audio Prompt button."
                         trigger={
-                            <Input
-                                label="Audio Prompt:"
-                                name="prompt"
-                                value={prompt}
-                                onChange={onPromptChange}
-                            />
+                            <Form.Field inline>
+                                <Input
+                                    label="Audio Prompt:"
+                                    name="prompt"
+                                    value={prompt}
+                                    onChange={onChange}
+                                />
+                                <Label pointing="left">
+                                    This component will fallback to a text input
+                                    prompt when Audio recording is not
+                                    supported.
+                                </Label>
+                            </Form.Field>
                         }
                     />
 
-                    <Message content="Note: This component will fallback to a text input prompt when Audio recording is not supported." />
-
-                    <Checkbox
-                        name="required"
-                        label="Required?"
-                        checked={required}
-                        onChange={onRequirementChange}
+                    <Message
+                        color={header ? 'grey' : 'pink'}
+                        content={
+                            <Popup
+                                content="Set a data header. This is only displayed in the data view and data download."
+                                trigger={
+                                    <Form.TextArea
+                                        required
+                                        label="Header"
+                                        name="header"
+                                        value={header}
+                                        onChange={onChange}
+                                    />
+                                }
+                            />
+                        }
                     />
                 </Container>
             </Form>
@@ -119,6 +140,7 @@ AudioResponseEditor.propTypes = {
     onChange: PropTypes.func.isRequired,
     scenarioId: PropTypes.string,
     value: PropTypes.shape({
+        header: PropTypes.string,
         prompt: PropTypes.string,
         recallId: PropTypes.string,
         required: PropTypes.bool,

--- a/client/components/Slide/Components/AudioResponse/index.js
+++ b/client/components/Slide/Components/AudioResponse/index.js
@@ -1,6 +1,7 @@
 import { type } from './type';
 export { type };
 export const defaultValue = ({ responseId }) => ({
+    header: '',
     prompt: 'Record your response',
     recallId: '',
     required: true,

--- a/client/components/Slide/Components/MultiButtonResponse/Editor.jsx
+++ b/client/components/Slide/Components/MultiButtonResponse/Editor.jsx
@@ -3,12 +3,13 @@ import PropTypes from 'prop-types';
 import {
     Accordion,
     Button,
-    Checkbox,
     Form,
     Icon,
     Input,
     List,
-    Menu
+    Menu,
+    Message,
+    Popup
 } from 'semantic-ui-react';
 import { type } from './type';
 import Sortable from 'react-sortablejs';
@@ -28,6 +29,7 @@ class MultiButtonResponseEditor extends React.Component {
                 }
                 */
             ],
+            header = '',
             prompt = '',
             recallId = '',
             required,
@@ -37,6 +39,7 @@ class MultiButtonResponseEditor extends React.Component {
         this.state = {
             activeIndex: recallId ? 0 : -1,
             buttons,
+            header,
             prompt,
             recallId,
             required,
@@ -46,34 +49,37 @@ class MultiButtonResponseEditor extends React.Component {
         this.onAddButton = this.onAddButton.bind(this);
         this.onChangeButtonDetail = this.onChangeButtonDetail.bind(this);
         this.onChangeButtonOrder = this.onChangeButtonOrder.bind(this);
-        this.onChangePrompt = this.onChangePrompt.bind(this);
+        this.onChange = this.onChange.bind(this);
         this.onDeleteButton = this.onDeleteButton.bind(this);
         this.onFocusButtonDetail = this.onFocusButtonDetail.bind(this);
         this.onRecallChange = this.onRecallChange.bind(this);
-        this.onRequirementChange = this.onRequirementChange.bind(this);
         this.toggleOptional = this.toggleOptional.bind(this);
 
         this.updateState = this.updateState.bind(this);
     }
 
     updateState() {
-        const { buttons, prompt, recallId, required, responseId } = this.state;
-        this.props.onChange({
-            type,
+        const {
             buttons,
+            header,
             prompt,
             recallId,
             required,
             responseId
+        } = this.state;
+        this.props.onChange({
+            buttons,
+            header,
+            prompt,
+            recallId,
+            required,
+            responseId,
+            type
         });
     }
 
     onRecallChange({ recallId }) {
         this.setState({ recallId }, this.updateState);
-    }
-
-    onRequirementChange(event, { name, checked }) {
-        this.setState({ [name]: checked }, this.updateState);
     }
 
     onAddButton() {
@@ -114,7 +120,7 @@ class MultiButtonResponseEditor extends React.Component {
         this.setState({ buttons }, this.updateState);
     }
 
-    onChangePrompt(event, { name, value }) {
+    onChange(event, { name, value }) {
         this.setState({ [name]: value }, this.updateState);
     }
 
@@ -138,16 +144,15 @@ class MultiButtonResponseEditor extends React.Component {
 
     render() {
         const { scenarioId } = this.props;
-        const { activeIndex, buttons, prompt, recallId, required } = this.state;
+        const { activeIndex, buttons, header, prompt, recallId } = this.state;
         const {
             onAddButton,
             onChangeButtonDetail,
             onChangeButtonOrder,
             onRecallChange,
-            onChangePrompt,
+            onChange,
             onDeleteButton,
             onFocusButtonDetail,
-            onRequirementChange,
             toggleOptional,
             updateState
         } = this;
@@ -179,7 +184,7 @@ class MultiButtonResponseEditor extends React.Component {
                     label="Prompt (displayed before buttons)"
                     name="prompt"
                     value={prompt}
-                    onChange={onChangePrompt}
+                    onChange={onChange}
                 />
                 <Button icon onClick={onAddButton}>
                     <Icon.Group size="large" style={{ marginRight: '0.5rem' }}>
@@ -250,11 +255,22 @@ class MultiButtonResponseEditor extends React.Component {
                         })}
                     </Sortable>
                 </List>
-                <Checkbox
-                    name="required"
-                    label="Required?"
-                    checked={required}
-                    onChange={onRequirementChange}
+                <Message
+                    color={header ? 'grey' : 'pink'}
+                    content={
+                        <Popup
+                            content="Set a data header. This is only displayed in the data view and data download."
+                            trigger={
+                                <Form.TextArea
+                                    required
+                                    label="Header"
+                                    name="header"
+                                    value={header}
+                                    onChange={onChange}
+                                />
+                            }
+                        />
+                    }
                 />
             </Form>
         );
@@ -266,6 +282,7 @@ MultiButtonResponseEditor.propTypes = {
     scenarioId: PropTypes.string,
     value: PropTypes.shape({
         buttons: PropTypes.array,
+        header: PropTypes.string,
         prompt: PropTypes.string,
         recallId: PropTypes.string,
         required: PropTypes.bool,

--- a/client/components/Slide/Components/MultiButtonResponse/index.js
+++ b/client/components/Slide/Components/MultiButtonResponse/index.js
@@ -2,6 +2,7 @@ import { type } from './type';
 export { type };
 export const defaultValue = ({ responseId }) => ({
     recallId: '',
+    header: '',
     required: true,
     responseId,
     type

--- a/client/components/Slide/Components/TextResponse/Editor.jsx
+++ b/client/components/Slide/Components/TextResponse/Editor.jsx
@@ -1,6 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Accordion, Checkbox, Container, Form, Icon } from 'semantic-ui-react';
+import {
+    Accordion,
+    Container,
+    Form,
+    Icon,
+    Message,
+    Popup
+} from 'semantic-ui-react';
 import { type } from './type';
 import ResponseRecall from '@components/Slide/Components/ResponseRecall/Editor';
 import './TextResponse.css';
@@ -10,14 +17,16 @@ class TextResponseEditor extends React.Component {
     constructor(props) {
         super(props);
         const {
+            header = '',
             prompt = 'Text Prompt (displayed before input field as label)',
-            placeholder = 'Placeholder Text',
+            placeholder = '',
             recallId = '',
             required,
             responseId = ''
         } = props.value;
         this.state = {
             activeIndex: recallId ? 0 : -1,
+            header,
             prompt,
             placeholder,
             recallId,
@@ -26,8 +35,6 @@ class TextResponseEditor extends React.Component {
         };
 
         this.onChange = this.onChange.bind(this);
-        this.onRequirementChange = this.onRequirementChange.bind(this);
-        this.onRecallChange = this.onRecallChange.bind(this);
         this.toggleOptional = this.toggleOptional.bind(this);
         this.updateState = this.updateState.bind(this);
     }
@@ -35,18 +42,13 @@ class TextResponseEditor extends React.Component {
     render() {
         const {
             activeIndex,
+            header,
             prompt,
             placeholder,
-            recallId,
-            required
+            recallId
         } = this.state;
         const { scenarioId } = this.props;
-        const {
-            onChange,
-            onRecallChange,
-            onRequirementChange,
-            toggleOptional
-        } = this;
+        const { onChange, onRecallChange, toggleOptional } = this;
         return (
             <Form>
                 <Container fluid>
@@ -84,11 +86,22 @@ class TextResponseEditor extends React.Component {
                         value={placeholder}
                         onChange={onChange}
                     />
-                    <Checkbox
-                        name="required"
-                        label="Required?"
-                        checked={required}
-                        onChange={onRequirementChange}
+                    <Message
+                        color={header ? 'grey' : 'pink'}
+                        content={
+                            <Popup
+                                content="Set a data header. This is only displayed in the data view and data download."
+                                trigger={
+                                    <Form.TextArea
+                                        required
+                                        label="Header"
+                                        name="header"
+                                        value={header}
+                                        onChange={onChange}
+                                    />
+                                }
+                            />
+                        }
                     />
                 </Container>
             </Form>
@@ -97,6 +110,7 @@ class TextResponseEditor extends React.Component {
 
     updateState() {
         const {
+            header,
             prompt,
             placeholder,
             recallId,
@@ -104,21 +118,18 @@ class TextResponseEditor extends React.Component {
             responseId
         } = this.state;
         this.props.onChange({
-            type,
+            header,
             prompt,
             placeholder,
             recallId,
             required,
-            responseId
+            responseId,
+            type
         });
     }
 
     onRecallChange({ recallId }) {
         this.setState({ recallId }, this.updateState);
-    }
-
-    onRequirementChange(event, { name, checked }) {
-        this.setState({ [name]: checked }, this.updateState);
     }
 
     onChange(event, { name, value }) {
@@ -138,6 +149,7 @@ TextResponseEditor.propTypes = {
     scenarioId: PropTypes.string,
     value: PropTypes.shape({
         placeholder: PropTypes.string,
+        header: PropTypes.string,
         prompt: PropTypes.string,
         recallId: PropTypes.string,
         required: PropTypes.bool,

--- a/client/components/Slide/SlideEditor/index.jsx
+++ b/client/components/Slide/SlideEditor/index.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
+    Checkbox,
     Dropdown,
     Grid,
     Icon,
@@ -138,6 +139,10 @@ export default class SlideEditor extends React.Component {
 
     onTitleBlur() {
         this.setState({ titleHasFocus: false });
+    }
+
+    onComponentRequirementChange(event, { checked }) {
+        this.setState({ required: checked }, this.updateState);
     }
 
     render() {
@@ -293,6 +298,38 @@ export default class SlideEditor extends React.Component {
                                         this,
                                         index
                                     );
+
+                                    const right = [];
+
+                                    if (value.responseId) {
+                                        const requiredCheckbox = (
+                                            <Menu.Item
+                                                key="menu-item-prompt-required"
+                                                name="Set this prompt to 'required'"
+                                            >
+                                                <Checkbox
+                                                    name="required"
+                                                    label="Required?"
+                                                    checked={value.required}
+                                                    onChange={(
+                                                        event,
+                                                        { checked }
+                                                    ) =>
+                                                        this.onComponentChange(
+                                                            index,
+                                                            {
+                                                                ...value,
+                                                                required: checked
+                                                            }
+                                                        )
+                                                    }
+                                                />
+                                            </Menu.Item>
+                                        );
+
+                                        right.push(requiredCheckbox);
+                                    }
+
                                     const componentMenu = (
                                         <EditorMenu
                                             type="component"
@@ -302,7 +339,8 @@ export default class SlideEditor extends React.Component {
                                                 },
                                                 delete: {
                                                     onConfirm: onDeleteComponentCurriedWithIndex
-                                                }
+                                                },
+                                                right
                                             }}
                                         />
                                     );


### PR DESCRIPTION
- Adds a "Header" field to all prompt components
- Moves the "Required?" checkbox into the component menu bar (it was confusing before)

https://app.asana.com/0/1127815256483386/1153693807822987/f


https://www.youtube.com/watch?v=VQ-Eh5H8dJY


Test 1: 

1. Add a prompt component, enter a header.
2. Refresh the page and the header value should still be present