### PR TITLE
Set default empty array values for scenario categories

### DIFF
--- a/client/components/ScenarioEditor/index.jsx
+++ b/client/components/ScenarioEditor/index.jsx
@@ -126,7 +126,7 @@ class ScenarioEditor extends Component {
 
     async onSubmit() {
         const {
-            categories,
+            categories = [],
             consent,
             description,
             finish,

--- a/client/components/ScenariosList/ScenarioCard.jsx
+++ b/client/components/ScenariosList/ScenarioCard.jsx
@@ -48,7 +48,7 @@ class ScenarioCard extends React.Component {
         const { isLoggedIn } = this.props;
         const { scenario } = this.state;
         const {
-            categories,
+            categories = [],
             id,
             description,
             deleted_at,


### PR DESCRIPTION
@rwaldron I'm not 100% sure of the repro steps for this, but when I went to "Continue Moments" as a participant user, I was getting an error that `includes` couldn't run on undefined. I think `categories` should by default be an empty array, so I also tried to account to for the one area where that's not getting save properly. 

Let me know what you think and if you can't repro.