### PR TITLE
Editor: when opening the Scenario Editor, wait until we have finish slide content to render the view

### DIFF
--- a/client/components/ScenarioEditor/index.jsx
+++ b/client/components/ScenarioEditor/index.jsx
@@ -196,6 +196,12 @@ class ScenarioEditor extends Component {
             title
         } = this.props;
 
+        // Stop letting the editor load before the
+        // finish slide is available.
+        if (!finish.components[0]) {
+            return null;
+        }
+
         const consentAgreementValue = {
             type: 'Text',
             html: consent.prose || ''

--- a/server/service/scenarios/endpoints.js
+++ b/server/service/scenarios/endpoints.js
@@ -244,6 +244,10 @@ exports.copyScenario = asyncMiddleware(async function copyScenarioAsync(
             }
         }
 
+        const { finish } = await db.getScenario(scenarioId);
+
+        originalSlides.push(finish);
+
         await setAllSlides(scenario.id, originalSlides);
 
         const consent = await db.getScenarioConsent(scenarioId);
@@ -256,7 +260,8 @@ exports.copyScenario = asyncMiddleware(async function copyScenarioAsync(
 
         Object.assign(scenario, {
             consent,
-            categories
+            categories,
+            finish
         });
         res.send({ scenario, status: 201 });
     } catch (apiError) {


### PR DESCRIPTION
I noticed that sometimes the Scenario editor renders scenarios before the finish slide is available, even when that scenario has a finish slide. This ensures that doesn't happen. I'm not sure how to test it, as it seemed to happen intermittently, so I suspect there is a race condition in our scenario loading. We can investigate that further at a later time.  