### PR TITLE
Editor: active slide index persistence; scroll to active slide between Slides and Preview; support direct to slide URLs

### DIFF
--- a/client/components/Editor/index.jsx
+++ b/client/components/Editor/index.jsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { Dropdown, Menu, Segment } from 'semantic-ui-react';
 import PropTypes from 'prop-types';
+import storage from 'local-storage-fallback';
 
 import EditorMenu from '@components/EditorMenu';
 import ScenarioEditor from '@components/ScenarioEditor';
@@ -20,40 +21,97 @@ class Editor extends Component {
     constructor(props) {
         super(props);
 
-        const scenarioId = this.props.match.params.id || 'new';
-
         this.copyScenario = this.copyScenario.bind(this);
         this.deleteScenario = this.deleteScenario.bind(this);
-        this.updateScenario = this.updateScenario.bind(this);
+        this.getAllTabs = this.getAllTabs.bind(this);
+        this.getPostSubmitCallback = this.getPostSubmitCallback.bind(this);
+        this.getSubmitCallback = this.getSubmitCallback.bind(this);
+        this.getTab = this.getTab.bind(this);
         this.onClick = this.onClick.bind(this);
         this.onClickScenarioAction = this.onClickScenarioAction.bind(this);
-        this.getSubmitCallback = this.getSubmitCallback.bind(this);
-        this.getPostSubmitCallback = this.getPostSubmitCallback.bind(this);
-        this.getTab = this.getTab.bind(this);
-        this.getAllTabs = this.getAllTabs.bind(this);
+        this.setActiveView = this.setActiveView.bind(this);
         this.updateEditorMessage = this.updateEditorMessage.bind(this);
+        this.updateScenario = this.updateScenario.bind(this);
+
+        let {
+            activeTab,
+            activeSlideIndex,
+            isCopyScenario,
+            isNewScenario,
+            match,
+            scenarioId
+        } = this.props;
+
+        if (!scenarioId) {
+            scenarioId = isNewScenario ? 'new' : match.params.id;
+        }
+
+        if (isNewScenario) {
+            activeTab = 'scenario';
+        }
+
+        if (!isCopyScenario && !isNewScenario) {
+            this.persistenceKey = `editor/${scenarioId}`;
+
+            let persisted = JSON.parse(storage.getItem(this.persistenceKey));
+
+            if (!persisted) {
+                persisted = { activeTab: 'scenario', activeSlideIndex };
+                storage.setItem(this.persistenceKey, JSON.stringify(persisted));
+            }
+
+            // These have already been declared as let bindings above
+            // but we may override those values here, with whatever
+            // was persisted for this scenario
+            ({ activeTab, activeSlideIndex } = persisted);
+        }
+
         this.state = {
-            activeTab: 'moment',
+            activeSlideIndex,
+            activeTab,
             editorMessage: '',
             saving: false,
-            scenarioId: scenarioId,
+            scenarioId,
             tabs: this.getAllTabs(scenarioId)
         };
 
-        switch (scenarioId) {
-            case 'new':
-            case 'copy':
-                break;
-            default:
-                this.state.activeTab = 'slides';
-                this.props.getScenario(scenarioId);
-                break;
+        if (isCopyScenario) {
+            this.copyScenario(scenarioId);
+        }
+
+        if (!isNewScenario) {
+            this.state.activeTab = 'slides';
+            this.props.getScenario(scenarioId);
         }
     }
 
-    onClick(e, { name }) {
-        this.setState({ activeTab: name });
+    onClick(e, { name: activeTab }) {
+        this.setState({ activeTab });
+
+        const persisted = JSON.parse(storage.getItem(this.persistenceKey));
+        const updated = {
+            ...persisted,
+            activeTab
+        };
+        const { scenarioId } = this.state;
+
+        storage.setItem(this.persistenceKey, JSON.stringify(updated));
+
+        const pathname = `/editor/${scenarioId}/${activeTab}/${updated.activeSlideIndex}`;
+        this.props.history.push(pathname);
         this.updateEditorMessage('');
+    }
+
+    setActiveView({ activeTab, activeSlideIndex }) {
+        const { scenarioId } = this.state;
+
+        const pathname = `/editor/${scenarioId}/${activeTab}/${activeSlideIndex}`;
+
+        storage.setItem(
+            this.persistenceKey,
+            JSON.stringify({ activeTab, activeSlideIndex })
+        );
+        this.props.history.push(pathname);
     }
 
     onClickScenarioAction(event, data) {
@@ -66,31 +124,23 @@ class Editor extends Component {
         }
     }
 
-    componentDidMount() {
-        if (this.state.scenarioId === 'copy') {
-            this.copyScenario();
-        }
-    }
+    async copyScenario(scenarioId) {
+        if (!scenarioId) return;
 
-    async copyScenario() {
-        const { scenarioCopyId } = this.props.location.state;
-        if (!scenarioCopyId) return;
-
-        const postSubmitCB = this.getPostSubmitCallback();
-        const copyResponse = await (await fetch(
-            `/api/scenarios/${scenarioCopyId}/copy`,
+        const { scenario, status } = await (await fetch(
+            `/api/scenarios/${scenarioId}/copy`,
             {
                 method: 'POST'
             }
         )).json();
 
-        if (copyResponse.status !== 201) {
+        if (status !== 201) {
             this.updateEditorMessage('Error saving copy.');
             return;
         }
 
-        this.props.setScenario(copyResponse.scenario);
-        postSubmitCB(copyResponse.scenario);
+        // Hard refresh to clear all previous state from the editor.
+        location.href = `/editor/${scenario.id}`;
     }
 
     async deleteScenario(scenarioId) {
@@ -99,12 +149,8 @@ class Editor extends Component {
         });
         await result.json();
 
-        this.setState({
-            scenarioId: 'new',
-            activeTab: 'moment'
-        });
-
-        this.props.history.push('/');
+        // Hard redirect to clear all previous state from the editor.
+        location.href = '/';
     }
 
     async updateScenario(updates = {}) {
@@ -145,7 +191,7 @@ class Editor extends Component {
         switch (response.status) {
             case 200:
                 this.props.setScenario(response.scenario);
-                this.updateEditorMessage('Teacher Moment saved');
+                this.updateEditorMessage('Scenario saved');
                 break;
             default:
                 if (response.error) {
@@ -156,11 +202,14 @@ class Editor extends Component {
     }
 
     getTab(name, scenarioId) {
+        const { activeSlideIndex = 0 } = this.state || this.props;
+        const { setActiveView } = this;
+
         switch (name) {
-            case 'moment':
+            case 'scenario':
                 return (
                     <ScenarioEditor
-                        scenarioId={scenarioId || this.props.match.params.id}
+                        scenarioId={scenarioId}
                         submitCB={this.getSubmitCallback()}
                         postSubmitCB={this.getPostSubmitCallback()}
                         updateEditorMessage={this.updateEditorMessage}
@@ -169,14 +218,28 @@ class Editor extends Component {
             case 'slides':
                 return (
                     <Slides
-                        scenarioId={scenarioId || this.props.match.params.id}
+                        setActiveSlide={activeSlideIndex =>
+                            setActiveView({
+                                activeSlideIndex,
+                                activeTab: 'slides'
+                            })
+                        }
+                        activeSlideIndex={activeSlideIndex}
+                        scenarioId={scenarioId}
                         updateEditorMessage={this.updateEditorMessage}
                     />
                 );
             case 'preview':
                 return (
                     <Scenario
-                        scenarioId={scenarioId || this.props.match.params.id}
+                        setActiveSlide={activeSlideIndex =>
+                            setActiveView({
+                                activeSlideIndex,
+                                activeTab: 'preview'
+                            })
+                        }
+                        activeSlideIndex={activeSlideIndex}
+                        scenarioId={scenarioId}
                     />
                 );
             default:
@@ -185,63 +248,52 @@ class Editor extends Component {
     }
 
     getAllTabs(scenarioId) {
-        if (!scenarioId) return {};
-        let copyId;
         switch (scenarioId) {
             case 'new':
                 return {
-                    moment: this.getTab('moment', 'new')
-                };
-            case 'copy':
-                copyId = String(this.props.location.state.scenarioCopyId);
-                return {
-                    moment: this.getTab('moment', copyId),
-                    slides: this.getTab('slides', copyId),
-                    preview: this.getTab('preview', copyId)
+                    scenario: this.getTab('scenario', 'new')
                 };
             default:
                 return {
-                    moment: this.getTab('moment'),
-                    slides: this.getTab('slides'),
-                    preview: this.getTab('preview')
+                    scenario: this.getTab('scenario', scenarioId),
+                    slides: this.getTab('slides', scenarioId),
+                    preview: this.getTab('preview', scenarioId)
                 };
         }
     }
 
     getSubmitCallback() {
         let endpoint, method;
-        const scenarioId = this.props.match.params.id;
+        const { isNewScenario, scenarioId } = this.props;
 
-        if (this.props.isNewScenario || scenarioId === 'copy') {
+        if (isNewScenario) {
             endpoint = '/api/scenarios';
             method = 'PUT';
         } else {
             endpoint = `/api/scenarios/${scenarioId}`;
             method = 'POST';
         }
-        return scenarioData => {
+        return scenario => {
             return fetch(endpoint, {
                 method,
                 headers: {
                     'Content-Type': 'application/json'
                 },
-                body: JSON.stringify(scenarioData)
+                body: JSON.stringify(scenario)
             });
         };
     }
 
     getPostSubmitCallback() {
-        if (this.props.isNewScenario || this.props.match.params.id === 'copy') {
-            return scenarioData => {
-                this.props.history.push(`/editor/${scenarioData.id}`);
-                this.setState({
-                    activeTab: 'moment',
-                    scenarioId: scenarioData.id
-                });
+        const { history, isCopyScenario, isNewScenario } = this.props;
+        const { setActiveView } = this;
 
-                // Clear cached new scenario values from tabs
-                const tabs = this.getAllTabs(scenarioData.id);
-                this.setState({ tabs });
+        if (isCopyScenario || isNewScenario) {
+            return scenario => {
+                history.push(`/editor/${scenario.id}`);
+                this.setState({ scenarioId: scenario.id }, () => {
+                    setActiveView({ activeTab: 'slides' });
+                });
             };
         }
 
@@ -321,12 +373,17 @@ EditorMessage.propTypes = {
 };
 
 Editor.propTypes = {
+    activeTab: PropTypes.string,
+    activeSlideIndex: PropTypes.number,
+    scenarioId: PropTypes.node,
     history: PropTypes.shape({
         push: PropTypes.func.isRequired
     }).isRequired,
     match: PropTypes.shape({
+        path: PropTypes.string,
         params: PropTypes.shape({
-            id: PropTypes.node
+            id: PropTypes.node,
+            activeSlideIndex: PropTypes.node
         }).isRequired
     }).isRequired,
     location: PropTypes.shape({
@@ -334,6 +391,7 @@ Editor.propTypes = {
             scenarioCopyId: PropTypes.node
         })
     }).isRequired,
+    isCopyScenario: PropTypes.bool,
     isNewScenario: PropTypes.bool,
     getScenario: PropTypes.func.isRequired,
     setScenario: PropTypes.func.isRequired,

--- a/client/components/Run/index.jsx
+++ b/client/components/Run/index.jsx
@@ -126,6 +126,7 @@ class Run extends Component {
                 onResponseChange={onResponseChange}
                 onRunChange={onChange}
                 onSubmit={onSubmit}
+                setActiveSlide={() => {}}
             />
         ) : (
             <Loader>Loading</Loader>

--- a/client/components/Scenario/Scenario.css
+++ b/client/components/Scenario/Scenario.css
@@ -33,3 +33,7 @@
     box-shadow: 0 0 0 0 !important;
     -webkit-box-shadow: 0 0 0 0 !important;
 }
+
+.scenario__slide-preview--selected {
+    border: 1px solid gold !important;
+}

--- a/client/components/ScenarioEditor/index.jsx
+++ b/client/components/ScenarioEditor/index.jsx
@@ -61,15 +61,14 @@ class ScenarioEditor extends Component {
                 categories: [],
                 status: 1
             });
+        } else {
+            this.props.getScenario(this.props.scenarioId);
         }
     }
 
     async componentDidMount() {
         const categories = await (await fetch('/api/tags/categories')).json();
         this.setState({ categories });
-        if (this.props.scenarioId !== 'new') {
-            await this.props.getScenario(this.props.scenarioId);
-        }
     }
 
     onChange(event, { name, value }) {

--- a/client/components/ScenariosList/ScenarioCard.jsx
+++ b/client/components/ScenariosList/ScenarioCard.jsx
@@ -116,12 +116,7 @@ class ScenarioCard extends React.Component {
                                     color="black"
                                     className="scenario__entry--button"
                                     as={Link}
-                                    to={{
-                                        pathname: `/editor/copy`,
-                                        state: {
-                                            scenarioCopyId: id
-                                        }
-                                    }}
+                                    to={{ pathname: `/editor/copy/${id}` }}
                                 >
                                     Copy
                                 </Button>

--- a/client/routes/RouteComponents.jsx
+++ b/client/routes/RouteComponents.jsx
@@ -18,6 +18,10 @@ export const NewScenario = props => {
     return <Editor {...props} isNewScenario={true} />;
 };
 
+export const CopyScenario = props => {
+    return <Editor {...props} isCopyScenario={true} />;
+};
+
 export const ScenariosListAll = props => {
     return <ScenariosList {...props} category="all" />;
 };

--- a/client/routes/Routes.jsx
+++ b/client/routes/Routes.jsx
@@ -10,12 +10,13 @@ import LoginRoutePromptModal from '@client/components/Login/LoginRoutePromptModa
 import CreateAnonymousAccount from '@client/components/CreateAccount/CreateAnonymousAccount';
 import Editor from '@client/components/Editor';
 import Login from '@client/components/Login';
-import { Logout } from './RouteComponents';
-import { NewScenario } from './RouteComponents';
 import Researcher from '@client/components/Researcher';
 import Run from '@client/components/Run';
 import {
+    CopyScenario,
+    Logout,
     InterceptAnonymizableRoute,
+    NewScenario,
     RedirectRouteForActiveSession,
     ScenariosListAll,
     ScenariosListAuthor,
@@ -23,6 +24,12 @@ import {
     ScenariosListContinue,
     ScenariosListOfficial
 } from './RouteComponents';
+
+const makeEditorProps = props => ({
+    ...props,
+    activeSlideIndex: Number(props.match.params.index || 0),
+    scenarioId: props.match.params.id
+});
 
 const Routes = () => {
     return (
@@ -87,10 +94,101 @@ const Routes = () => {
                 <Route component={NewScenario} />
             </ConfirmAuth>
             <ConfirmAuth
+                path="/editor/copy/:id"
+                requiredPermission="create_scenario"
+            >
+                <Route component={CopyScenario} />
+            </ConfirmAuth>
+
+            <ConfirmAuth
+                path="/editor/:id/scenario"
+                requiredPermission="create_scenario"
+            >
+                <Route
+                    render={props => {
+                        return (
+                            <Editor
+                                {...makeEditorProps(props)}
+                                activeTab="scenario"
+                            />
+                        );
+                    }}
+                />
+            </ConfirmAuth>
+            <ConfirmAuth
+                path="/editor/:id/slides/:activeSlideIndex"
+                requiredPermission="create_scenario"
+            >
+                <Route
+                    render={props => {
+                        return (
+                            <Editor
+                                {...makeEditorProps(props)}
+                                activeTab="slides"
+                            />
+                        );
+                    }}
+                />
+            </ConfirmAuth>
+            <ConfirmAuth
+                path="/editor/:id/slides"
+                requiredPermission="create_scenario"
+            >
+                <Route
+                    render={props => {
+                        return (
+                            <Editor
+                                {...makeEditorProps(props)}
+                                activeTab="slides"
+                            />
+                        );
+                    }}
+                />
+            </ConfirmAuth>
+            <ConfirmAuth
+                path="/editor/:id/preview/:activeSlideIndex"
+                requiredPermission="create_scenario"
+            >
+                <Route
+                    render={props => {
+                        return (
+                            <Editor
+                                {...makeEditorProps(props)}
+                                activeTab="preview"
+                            />
+                        );
+                    }}
+                />
+            </ConfirmAuth>
+            <ConfirmAuth
+                path="/editor/:id/preview"
+                requiredPermission="create_scenario"
+            >
+                <Route
+                    render={props => {
+                        return (
+                            <Editor
+                                {...makeEditorProps(props)}
+                                activeTab="preview"
+                            />
+                        );
+                    }}
+                />
+            </ConfirmAuth>
+            <ConfirmAuth
                 path="/editor/:id"
                 requiredPermission="create_scenario"
             >
-                <Route component={Editor} />
+                <Route
+                    render={props => {
+                        return (
+                            <Editor
+                                {...makeEditorProps(props)}
+                                activeTab="scenario"
+                            />
+                        );
+                    }}
+                />
             </ConfirmAuth>
             <ConfirmAuth path="/research" requiredPermission="view_run_data">
                 <Route component={Researcher} />


### PR DESCRIPTION
Changes: 

- New routes to support urls that enable direct-to-slide access in the slide editor and the slide preview views
- In the Slide Editor: 
    - Selecting a slide scrolls that slide to top of the slide list. 
    - Adding a new slide scrolls that new slide to top of the slide list. 
    - Moving a slide scrolls that slide to top of the slide list. 
    - Whatever slide is selected in the Preview pane will be scrolled to the top of the Slide Editor pane.
- In the Preview pane:  
    - Selecting a slide scrolls that slide to top of the Preview pane.
    - Whatever slide is selected in the Slide Editor pane will be scrolled to the top of the Preview pane.
- Toggling between the Slides and Preview panes keeps the slide index synced
    - Excluding the "Entry" and "Finish" slides in Preview pane, since those do not correspond to a Slide in the Slide Editor


Testing...

Test 1: 

- Make a scenario with 10 slides, I suggest giving them titles: `0`,`1`,`2`,`3`,`4`,`5`,`6`,`7`,`8`,`9`
- The most recently added slide should always slide to the top of the slide list.

Test 2:  

- Scroll the list of slides so that Slide `0` is at the top. Click any visible portion of Slide `2`.
- Slide `2` should scroll to the top of the slide list.
- Switch to the Preview pane, Slide `2` should scroll to the top of the preview list.
- Switch to the Slide Editor pane, Slide `2` should scroll to the top of the slide list.

Test 3:  

- Click and drag Slide `2` below  Slide `3`.
- Slide `2` should scroll to the top of the slide list.
- Switch to the Preview pane, Slide `2` should scroll to the top of the preview list.
- Switch to the Slide Editor pane, Slide `2` should scroll to the top of the slide list.


Test 4:  

- Click "Add a slide".
- The new slide should appear after Slide `2`, and should scroll to the top of the slide list.
- Switch to the Preview pane, the new slide should scroll to the top of the preview list.
- Switch to the Slide Editor pane,  the new slide should scroll to the top of the slide list.
- Delete the new slide
- Slide `2` should be selected and will slide to the top of the slide list. 
- Switch to the Preview pane, Slide `2` should scroll to the top of the preview list.
- Switch to the Slide Editor pane, Slide `2` should scroll to the top of the slide list.

Test 5:

- Click and drag Slide `3` below Slide `2`.
- Slide `3` should scroll to the top of the slide list.
- Switch to the Preview pane, Slide `3` should scroll to the top of the preview list.
- Switch to the Slide Editor pane, Slide `3` should scroll to the top of the slide list.

Test 6: 

- In Slide `5`, add a component so that it's easily recognized, for example: "This is slide 5"
- Copy the url from the address bar
- Open a new tab and paste the url, hit enter.
- Slide `5` should be selected and displayed in the slide editor, the slide should be scrolled to the top of the slide list.

Test 7: 

- Do a **Run** of this scenario and make sure that the navigational behavior and url pathnames are correct for a run, they should be: 
  - Entry Slide: /slide/0
  - Slide titled `0`: /slide/1
  - Slide titled `1`: /slide/2
  - Slide titled `2`: /slide/3
  - Slide titled `3`: /slide/4
  - Slide titled `4`: /slide/5
  - Slide titled `5`: /slide/6
  - Slide titled `6`: /slide/7
  - Slide titled `7`: /slide/8
  - Slide titled `8`: /slide/9
  - Slide titled `9`: /slide/10
  - Finish Slide: /slide/11

