### PR TITLE
Re-add research view to nav

### DIFF
--- a/client/routes/Navigation.jsx
+++ b/client/routes/Navigation.jsx
@@ -26,6 +26,11 @@ const restrictedNav = [
         permission: 'view_invited_cohorts'
     },
     {
+        text: 'Research',
+        path: '/research',
+        permission: 'view_run_data'
+    },
+    {
         text: 'Account Administration',
         path: '/account-administration',
         permission: 'edit_permissions'

--- a/client/routes/Routes.jsx
+++ b/client/routes/Routes.jsx
@@ -105,7 +105,7 @@ const Routes = () => {
             >
                 <Route component={Editor} />
             </ConfirmAuth>
-            <ConfirmAuth path="/researcher" requiredPermission="view_run_data">
+            <ConfirmAuth path="/research" requiredPermission="view_run_data">
                 <Route component={Researcher} />
             </ConfirmAuth>
             <Route exact path="/logout" component={Logout} />


### PR DESCRIPTION
@rwaldron this PR re-adds the researcher data download view to the nav. 

Test:
- As a user with a researcher role, click on "Research" in the main nav
- Pick a scenario from the dropdown and click "Download CSV"
- Confirm your CSV file downloads and it contains the scenario's participant response data.