### PR TITLE
Cohorts: participants can see all of their own cohorts

### DIFF
--- a/client/components/Facilitator/Components/Cohorts/Cohort.jsx
+++ b/client/components/Facilitator/Components/Cohorts/Cohort.jsx
@@ -34,17 +34,6 @@ export class Cohort extends React.Component {
         if (location && location.search) {
             storage.setItem(`referrer_params`, location.search);
         }
-        // This is a hack to get through the testing on Monday.
-        {
-            let localCohort = storage.getItem('cohort');
-            if (id && localCohort !== id) {
-                storage.setItem('cohort', id);
-            } else {
-                if (localCohort !== null) {
-                    id = Number(localCohort);
-                }
-            }
-        }
 
         this.persistenceKey = `cohort/${id}`;
         let cohortPersisted = JSON.parse(storage.getItem(this.persistenceKey));

--- a/client/components/Facilitator/Components/Cohorts/index.jsx
+++ b/client/components/Facilitator/Components/Cohorts/index.jsx
@@ -23,6 +23,7 @@ import {
     createCohort
 } from '@client/actions/cohort';
 import { getScenarios } from '@client/actions/scenario';
+import ConfirmAuth from '@client/components/ConfirmAuth';
 import CohortCard from './CohortCard';
 import CohortEmpty from './CohortEmpty';
 import EditorMenu from '@components/EditorMenu';
@@ -92,21 +93,26 @@ export class Cohorts extends React.Component {
                     type="cohorts"
                     items={{
                         left: [
-                            <Menu.Item
-                                key="menu-item-create-cohort"
-                                name="Create a cohort"
-                                onClick={onClickOpenCreateCohort}
-                                className="cohort__menu-item--padding"
+                            <ConfirmAuth
+                                key="menu-item-create-cohort-auth"
+                                requiredPermission="edit_all_cohorts"
                             >
-                                <Icon.Group>
-                                    <Icon name="group" />
-                                    <Icon
-                                        corner="top right"
-                                        name="add"
-                                        color="green"
-                                    />
-                                </Icon.Group>
-                            </Menu.Item>
+                                <Menu.Item
+                                    key="menu-item-create-cohort"
+                                    name="Create a cohort"
+                                    onClick={onClickOpenCreateCohort}
+                                    className="cohort__menu-item--padding"
+                                >
+                                    <Icon.Group>
+                                        <Icon name="group" />
+                                        <Icon
+                                            corner="top right"
+                                            name="add"
+                                            color="green"
+                                        />
+                                    </Icon.Group>
+                                </Menu.Item>
+                            </ConfirmAuth>
                         ],
                         search: {
                             source: cohorts,

--- a/client/routes/Navigation.jsx
+++ b/client/routes/Navigation.jsx
@@ -18,12 +18,7 @@ const restrictedNav = [
     {
         text: 'Cohorts',
         path: '/cohorts',
-        permission: 'create_cohort'
-    },
-    {
-        text: 'My Cohort',
-        path: '/cohort',
-        permission: 'view_invited_cohorts'
+        permission: 'view_own_cohorts'
     },
     {
         text: 'Research',

--- a/client/routes/Routes.jsx
+++ b/client/routes/Routes.jsx
@@ -2,13 +2,13 @@ import React from 'react';
 import { Route, Switch } from 'react-router-dom';
 
 import AccountAdmin from '@client/components/AccountAdmin';
+import Cohorts from '@client/components/Facilitator/Components/Cohorts';
 import Cohort from '@client/components/Facilitator/Components/Cohorts/Cohort';
 import ConfirmAuth from '@client/components/ConfirmAuth';
 import CreateAccount from '@client/components/CreateAccount';
 import LoginRoutePromptModal from '@client/components/Login/LoginRoutePromptModal';
 import CreateAnonymousAccount from '@client/components/CreateAccount/CreateAnonymousAccount';
 import Editor from '@client/components/Editor';
-import Facilitator from '@client/components/Facilitator';
 import Login from '@client/components/Login';
 import { Logout } from './RouteComponents';
 import { NewScenario } from './RouteComponents';
@@ -58,31 +58,18 @@ const Routes = () => {
             >
                 <Route component={AccountAdmin} />
             </ConfirmAuth>
-            <ConfirmAuth
-                exact
-                path="/cohorts"
-                requiredPermission="view_all_cohorts"
-            >
+
+            <ConfirmAuth path="/cohorts" requiredPermission="view_own_cohorts">
                 <Route
-                    component={props => (
-                        <Facilitator {...props} activeTab="cohorts" />
-                    )}
+                    render={props => <Cohorts {...props} activeTab="cohorts" />}
                 />
             </ConfirmAuth>
+
             <InterceptAnonymizableRoute exact path="/cohort/:id">
                 <Route
                     render={props => <Cohort {...props} activeTab="cohort" />}
                 />
             </InterceptAnonymizableRoute>
-
-            <ConfirmAuth
-                path="/cohort"
-                requiredPermission="view_invited_cohorts"
-            >
-                <Route
-                    render={props => <Cohort {...props} activeTab="cohort" />}
-                />
-            </ConfirmAuth>
 
             <ConfirmAuth
                 exact

--- a/server/migrations/20191213160505-cohort-participant-can-view-all-own-cohorts.js
+++ b/server/migrations/20191213160505-cohort-participant-can-view-all-own-cohorts.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const sqlFile = require('./helpers/sql-file')(__filename);
+exports.up = function(db) {
+    return db.runSql(sqlFile.up);
+};
+exports.down = function(db) {
+    return db.runSql(sqlFile.down);
+};
+exports._meta = {
+    version: 1
+};

--- a/server/migrations/sql/20191213160505-cohort-participant-can-view-all-own-cohorts.sql
+++ b/server/migrations/sql/20191213160505-cohort-participant-can-view-all-own-cohorts.sql
@@ -1,0 +1,13 @@
+INSERT INTO role_permission (role, permission)
+VALUES
+    ('admin', 'view_own_cohorts'),
+    ('participant', 'view_own_cohorts'),
+    ('super_admin', 'view_own_cohorts')
+;
+
+-- Up above
+---
+-- Down below
+DELETE FROM role_permission
+WHERE permission = 'view_own_cohorts'
+AND role IN ('super_admin', 'admin', 'researcher');


### PR DESCRIPTION
- Adds "view_own_cohorts" to "participant" (and super admin, where it was oddly missing)
- Removes "My Cohort"
- Participant sees "/cohorts", but only their own cohorts

Test: 

- As a participant, click "Cohorts" and see the cohorts you've received a link to and visited.
- Join more cohorts as a participant, see them all