### PR TITLE
Add script and yarn command for seeding a super user

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -21,6 +21,7 @@
     "dev": "nodemon index.js",
     "lint": "eslint --ext js .",
     "prettier": "prettier --write \"**/*.js\"",
+    "seed:super-admin": "node seed/super-admin.js",
     "test": "yarn workspace test run test:server"
   },
   "dependencies": {

--- a/server/seed/super-admin.js
+++ b/server/seed/super-admin.js
@@ -1,0 +1,31 @@
+const { createUser } = require('../service/auth/db');
+const { addUserRoles } = require('../service/roles/db');
+
+async function seedSuperUser({ email, username, password }) {
+    if (!email || !username || !password) {
+        console.error('Missing argument for an email, username or password');
+        return;
+    }
+
+    const { id } = await createUser({ email, username, password });
+    const { addedCount } = await addUserRoles(id, ['super_admin']);
+    if (!id || !addedCount) {
+        console.error('Error creating user');
+        return;
+    }
+
+    // eslint-disable-next-line no-console
+    console.log(
+        `Super admin account created for ${username} with the email address ${email}`
+    );
+}
+
+const argsv = process.argv.slice(2);
+const scriptArgs = {};
+
+argsv.forEach(arg => {
+    const parsedArg = arg.split('=');
+    scriptArgs[parsedArg[0]] = parsedArg[1];
+});
+
+seedSuperUser(scriptArgs);


### PR DESCRIPTION
@rwaldron this PR allows you to create a super admin user and pass arguments for the user details. An example of how you'd run this command from the root of the project:

`yarn workspace server seed:super-admin email="test@email.com" username="SeedAdmin" password="test"`

This creates a super admin user with the username SeedAdmin, ect. I have a follow up task to document this and permissions stuff already.