### PR TITLE
Cohort: Scenario list button uses a whole table cell for a button

### DIFF
--- a/client/components/Facilitator/Components/Cohorts/Cohort.css
+++ b/client/components/Facilitator/Components/Cohorts/Cohort.css
@@ -9,6 +9,14 @@
     margin-bottom: 1rem;
 }
 
+@media only screen and (max-width: 767px) {
+    .ui.container.cohort__table-container {
+        width: auto !important;
+        margin-left: 0em !important;
+        margin-right: 0em !important;
+    }
+}
+
 .cohort__table-thead-tbody-tr {
     display: table;
     width: 100%;
@@ -68,6 +76,10 @@
 .cohort__tab-menu--overflow {
     overflow-x: auto;
     overflow-y: hidden;
+}
+
+.cohort__table-row--menu {
+    width: 9.6rem !important;
 }
 
 .cohort__tab-menu--button-transparent {

--- a/client/components/Facilitator/Components/Cohorts/CohortScenarios.jsx
+++ b/client/components/Facilitator/Components/Cohorts/CohortScenarios.jsx
@@ -181,7 +181,7 @@ export class CohortScenarios extends React.Component {
         return (
             <Container fluid className="cohort__table-container">
                 <Table
-                    celled
+                    fixed
                     striped
                     selectable
                     role="grid"
@@ -263,17 +263,14 @@ export class CohortScenarios extends React.Component {
                                                     />
                                                 </Table.Cell>
                                             </ConfirmAuth>
-                                            <Table.Cell>
-                                                <Button.Group
-                                                    hidden
-                                                    basic
-                                                    size="small"
-                                                    className="cohort__button-group--transparent"
-                                                    style={{
-                                                        marginRight: '0.5rem'
-                                                    }}
-                                                >
-                                                    <ConfirmAuth requiredPermission="edit_scenarios_in_cohort">
+                                            <ConfirmAuth requiredPermission="edit_scenarios_in_cohort">
+                                                <Table.Cell className="cohort__table-row--menu">
+                                                    <Button.Group
+                                                        hidden
+                                                        basic
+                                                        size="small"
+                                                        className="cohort__button-group--transparent"
+                                                    >
                                                         <Popup
                                                             content="Copy cohort scenario link to clipboard"
                                                             trigger={
@@ -306,28 +303,35 @@ export class CohortScenarios extends React.Component {
                                                                 />
                                                             }
                                                         />
-                                                    </ConfirmAuth>
-                                                    <ConfirmAuth requiredPermission="view_all_data">
-                                                        <Popup
-                                                            content="View cohort reponses to prompts in this scenario"
-                                                            trigger={
-                                                                <Button
-                                                                    icon
-                                                                    content={
-                                                                        <Icon name="file alternate outline" />
-                                                                    }
-                                                                    name={
-                                                                        scenario.title
-                                                                    }
-                                                                    onClick={
-                                                                        onClickAddTab
-                                                                    }
-                                                                    {...props}
-                                                                />
-                                                            }
-                                                        />
-                                                    </ConfirmAuth>
-                                                </Button.Group>
+
+                                                        <ConfirmAuth requiredPermission="view_all_data">
+                                                            <Popup
+                                                                content="View cohort reponses to prompts in this scenario"
+                                                                trigger={
+                                                                    <Button
+                                                                        icon
+                                                                        content={
+                                                                            <Icon name="file alternate outline" />
+                                                                        }
+                                                                        name={
+                                                                            scenario.title
+                                                                        }
+                                                                        onClick={
+                                                                            onClickAddTab
+                                                                        }
+                                                                        {...props}
+                                                                    />
+                                                                }
+                                                            />
+                                                        </ConfirmAuth>
+                                                    </Button.Group>
+                                                </Table.Cell>
+                                            </ConfirmAuth>
+                                            <Table.Cell
+                                                onClick={() => {
+                                                    location.href = url;
+                                                }}
+                                            >
                                                 <NavLink to={pathname}>
                                                     {scenario.title}
                                                 </NavLink>


### PR DESCRIPTION
https://app.asana.com/0/1127815256483386/1153863291171427/f

Changes: 

- Move the button bar into its own table cell
- Convert the whole cell into a clickable area, but preserve the anchor link

Test: 

- Click anywhere, it should open the scenario
