### PR TITLE
Cohort: add response duration to data download

### DIFF
--- a/client/components/Facilitator/Components/Cohorts/CohortDataTable.css
+++ b/client/components/Facilitator/Components/Cohorts/CohortDataTable.css
@@ -40,11 +40,13 @@
 }
 .datatable__scroll tbody td {
     max-width: 100px;
+    overflow-wrap: break-word;
 }
 
 .datatablemodal__scroll tbody td {
     min-width: 100px;
     overflow: visible !important;
+    overflow-wrap: break-word;
     white-space: inherit !important;
     text-overflow: unset !important;
 }

--- a/client/components/Facilitator/Components/Cohorts/CohortDataTable.jsx
+++ b/client/components/Facilitator/Components/Cohorts/CohortDataTable.jsx
@@ -241,6 +241,16 @@ export class CohortDataTable extends React.Component {
                     if (isAudioContent) {
                         content += ` (${location.origin}/api/media/${response.value})`;
                     }
+
+                    const difference = moment(response.ended_at).diff(
+                        response.created_at
+                    );
+                    const duration = moment
+                        .duration(difference)
+                        .format(moment.globalFormat);
+
+                    content += ` (${duration})`;
+
                     const formatted = CSV.escape(content);
 
                     return `"${formatted}"`;

--- a/client/components/Slide/Components/ResponseRecall/Display.jsx
+++ b/client/components/Slide/Components/ResponseRecall/Display.jsx
@@ -64,7 +64,10 @@ class Display extends React.Component {
         return (
             <Message
                 floating
-                style={{ whiteSpace: 'pre-wrap' }}
+                style={{
+                    whiteSpace: 'pre-wrap',
+                    overflowWrap: 'break-word'
+                }}
                 content={
                     content.endsWith('mp3') ? (
                         <React.Fragment>

--- a/client/components/Slide/Components/Text/Text.css
+++ b/client/components/Slide/Components/Text/Text.css
@@ -1,3 +1,6 @@
+.richtext__container {
+    overflow-wrap: break-word;
+}
 .richtext__container img {
     max-width: 100%;
 }


### PR DESCRIPTION
This builds on https://github.com/bocoup/threeflows/pull/227 and https://github.com/bocoup/threeflows/pull/228, so it must be rebased once those land. 

--------------------------------------------------------------------------------

Pre-test: 

- Log in as a user with Cohort Facilitator role/permissions
- Click "Cohorts" in the top navigation menu, select a cohort that is known to have have run response data

Test 1: 

- Click a Scenario title, once the tab has loaded, click that Scenario's "Download" icon\*
- Observe in the downloaded data that each response cell's contents end with a `(time)`

Test 2: 

- Click a Participant username, once the tab has loaded, click that Participant's "Download" icon\*
- Observe in the downloaded data that each response cell's contents end with a `(time)`

------------------------------------------------------
\* "Download" icon: 
![image](https://user-images.githubusercontent.com/27985/71013997-36e45f00-20bf-11ea-9491-928d7a63e602.png)

