### PR TITLE
Editor: highlighting text with cursor must not drag slide element

### DIFF
--- a/client/components/Slide/SlideEditor/index.jsx
+++ b/client/components/Slide/SlideEditor/index.jsx
@@ -272,9 +272,11 @@ export default class SlideEditor extends React.Component {
                             <Sortable
                                 onChange={onChangeComponentOrder}
                                 options={{
+                                    animation: 150,
                                     direction: 'vertical',
-                                    swapThreshold: 0.5,
-                                    animation: 150
+                                    draggable: '.draggable',
+                                    forceFallback: true,
+                                    swapThreshold: 0.5
                                 }}
                             >
                                 {components.map((value, index) => {
@@ -351,8 +353,8 @@ export default class SlideEditor extends React.Component {
                                             className={
                                                 index ===
                                                 this.state.currentComponentIndex
-                                                    ? 'editor__component-selected'
-                                                    : ''
+                                                    ? 'editor__component-selected draggable'
+                                                    : 'draggable'
                                             }
                                             onClick={() =>
                                                 this.setState({


### PR DESCRIPTION
Fixes: https://app.asana.com/0/1127815256483386/1152537018034528/f

By adding an explicit ".draggable" class to the elements that should respond to drag, and forcing the Sortable to use its fallback path, the drag response is limited to only elements with the ".draggable" class.

Test 1: 

- Attempt to reproduce reported behavior: 

> 1. Reproduction steps
>     1. Within a slide, add a new element (specifically Participant Suggestion, Text Input Prompt, Multiple Button Prompt, or Audio Response).
>     2. Use your cursor to drag-highlight the placeholder text within the new element.
> 2. Description
>     1. When a new slide element is added, if the mouse cursor is used to highlight placeholder text, it often will cause the whole element box to be moved (in a drag-and-drop way). Sometimes this also results in text from the surrounding area being dragged into the text box.


Here's a video of the bug being reproduced, before the fix: 

https://www.youtube.com/watch?v=gJd03tQ4mJU

Here's a video of several failed attempts to reproduce, after the fix: 

https://www.youtube.com/watch?v=gDz1FvpiHI4
