### PR TITLE
Cohorts: "create cohort" permission correction

### DIFF
--- a/client/components/Facilitator/Components/Cohorts/index.jsx
+++ b/client/components/Facilitator/Components/Cohorts/index.jsx
@@ -95,7 +95,7 @@ export class Cohorts extends React.Component {
                         left: [
                             <ConfirmAuth
                                 key="menu-item-create-cohort-auth"
-                                requiredPermission="edit_all_cohorts"
+                                requiredPermission="create_cohort"
                             >
                                 <Menu.Item
                                     key="menu-item-create-cohort"


### PR DESCRIPTION
- "edit_all_cohorts" is restricted to "super admin" and "admin" and its use here was a mistake.
- "create_cohort" is the correct permission