### PR TITLE
SQL: when encoding queries, don't accidentally typecast null to jsonb

### DIFF
--- a/server/util/sqlHelpers.js
+++ b/server/util/sqlHelpers.js
@@ -1,5 +1,5 @@
 function encodeValue(value) {
-    if (Array.isArray(value) || typeof value === 'object') {
+    if (Array.isArray(value) || (typeof value === 'object' && value !== null)) {
         const typecast = '::jsonb';
         return { typecast, value: JSON.stringify(value) };
     }


### PR DESCRIPTION
Prevents erroneously typecasting `null` values, because `typeof value === 'object' is true when `value` is `null`, therefore encoding with `::jsonb` even if the field is not a `::jsonb` field. The following JSONB fields are unaffected by this change, for the provided reason: 

- `audio_transcript.response JSONB`, which never receives a `null` value, as it's received from IBM Watson's `SpeechToTextV1` API via `recognize(...)` which responds with a `SpeechRecognitionResults[]` and is never `null`
- `run.referrer_params JSONB`, which never receives a `null` value, as it's _only_ updated when there are non-null/non-undefined values, which are always initialized with `{}` (via `JSON.parse()` or `QueryString.parse()`)
- `run_response.response JSONB`, which never receives a `null` value, as it's always initialized with `{}`
- `slide.components JSONB`, which never receives a `null` value, as it's always initialized with `[]`

