### PR TITLE
Add dropdown for admin users to change scenario authors

### DIFF
--- a/client/components/ScenarioEditor/DropdownOptions.jsx
+++ b/client/components/ScenarioEditor/DropdownOptions.jsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Dropdown, Form } from 'semantic-ui-react';
+
+export const CategoriesDropdown = ({
+    categoryOptions,
+    scenarioCategories,
+    onChange
+}) => {
+    return (
+        <Form.Field>
+            <label>Categories</label>
+            <Dropdown
+                label="Categories"
+                name="categories"
+                placeholder="Select..."
+                fluid
+                multiple
+                selection
+                options={categoryOptions.map(category => ({
+                    key: category.id,
+                    text: category.name,
+                    value: category.name
+                }))}
+                defaultValue={scenarioCategories}
+                onChange={onChange}
+            />
+        </Form.Field>
+    );
+};
+
+export const AuthorDropdown = ({ authorOptions, scenarioAuthor, onChange }) => {
+    return (
+        <Form.Field>
+            <label>Author</label>
+            <Dropdown
+                label="Author"
+                name="author"
+                placeholder="Select..."
+                fluid
+                multiple={false}
+                selection
+                options={authorOptions.map(author => ({
+                    key: author.username,
+                    text: author.username,
+                    value: author.username
+                }))}
+                defaultValue={scenarioAuthor}
+                onChange={onChange}
+            />
+        </Form.Field>
+    );
+};
+
+CategoriesDropdown.propTypes = {
+    categoryOptions: PropTypes.array.isRequired,
+    scenarioCategories: PropTypes.array.isRequired,
+    onChange: PropTypes.func.isRequired
+};
+
+AuthorDropdown.propTypes = {
+    authorOptions: PropTypes.array.isRequired,
+    scenarioAuthor: PropTypes.string,
+    onChange: PropTypes.func.isRequired
+};

--- a/client/reducers/scenario.js
+++ b/client/reducers/scenario.js
@@ -19,6 +19,7 @@ import {
 const initialScenarioState = {
     title: '',
     description: '',
+    author: '',
     consent: {
         id: null,
         prose: ''

--- a/server/service/roles/endpoints.js
+++ b/server/service/roles/endpoints.js
@@ -41,6 +41,15 @@ exports.getUserPermissions = asyncMiddleware(async function getUserPermissions(
     res.json(userPermissions);
 });
 
+exports.getUsersByPermission = asyncMiddleware(
+    async function getUsersByPermission(req, res) {
+        const permission = req.body.permission;
+        const usersWithPermission = await db.getUsersByPermission(permission);
+
+        res.send(usersWithPermission);
+    }
+);
+
 exports.addUserRoles = asyncMiddleware(async function addUserRolesAsync(
     req,
     res

--- a/server/service/roles/index.js
+++ b/server/service/roles/index.js
@@ -9,6 +9,7 @@ const {
     getAllUsersRoles,
     getUserRoles,
     getUserPermissions,
+    getUsersByPermission,
     addUserRoles,
     deleteUserRoles,
     setUserRoles
@@ -17,6 +18,8 @@ const {
 router.get('/', [requireUserRole('admin'), getAllUsersRoles]);
 
 router.get('/permission', [getUserPermissions]);
+
+router.post('/user/permission', [getUsersByPermission]);
 
 router.get('/:user_id', [requireUserRole('admin'), getUserRoles]);
 

--- a/server/service/scenarios/db.js
+++ b/server/service/scenarios/db.js
@@ -2,6 +2,7 @@ const { sql, updateQuery } = require('../../util/sqlHelpers');
 const { query } = require('../../util/db');
 const { addSlide, getSlidesForScenario } = require('./slides/db');
 const { getRunResponses } = require('../runs/db');
+const { getUserByProps } = require('../auth/db');
 
 async function getScenarioCategories(scenarioId) {
     const scenarioCategoriesResults = await query(sql`
@@ -72,6 +73,8 @@ async function getScenario(scenarioId) {
         SELECT * FROM scenario WHERE id = ${scenarioId};
     `);
 
+    const { author_id } = results.rows[0];
+    const { username: author } = await getUserByProps({ id: author_id });
     const categories = await getScenarioCategories(scenarioId);
     const consent = await getScenarioConsent(scenarioId);
     const finish =
@@ -79,8 +82,10 @@ async function getScenario(scenarioId) {
             slide => slide.is_finish
         ) || (await addFinishSlide(scenarioId));
 
+    delete results.rows[0].author_id;
     return {
         ...results.rows[0],
+        author,
         categories,
         consent,
         finish


### PR DESCRIPTION
Proposed changes:
- Add drop down in the "Scenario" tab for setting the Scenario's author
- Add API endpoint for getting all users that have authoring privileges
- In the API, add a check for an author username when adding or updating a scenario and if set, use that author's ID

<img width="1139" alt="Screen Shot 2019-12-19 at 10 54 28 AM" src="https://user-images.githubusercontent.com/7991694/71188203-89a05100-224e-11ea-9e43-da7a6ef2b573.png">

Test 1: 
- Create a new scenario (can be admin user or not)
- Fill in just the title and description, hit save
- Observe the logged in user is the author as a default if one isn't set

Test 2:
- As an admin, create a new scenario
- Choose an author different from your username and save
- Observe that new scenario has the author you chose

Test 3:
- Edit an existing scenario
- Change the author and hit save
- Refresh the editor and confirm that your author change has saved