### PR TITLE
ScenarioList: scenario lists should respect scenario status.

### DIFF
--- a/client/components/ScenariosList/ScenarioEntries.jsx
+++ b/client/components/ScenariosList/ScenarioEntries.jsx
@@ -3,18 +3,39 @@ import PropTypes from 'prop-types';
 
 import ScenarioCard from './ScenarioCard';
 
+/* eslint-disable */
+const SCENARIO_STATUS_DRAFT = 1;
+const SCENARIO_STATUS_PUBLIC = 2;
+const SCENARIO_STATUS_PRIVATE = 3;
+/* eslint-enable */
+
 const ScenarioEntries = ({ scenarios, isLoggedIn }) => {
     if (!scenarios.length) return null;
 
-    return scenarios.map(scenario => {
-        return (
+    return scenarios.reduce((accum, scenario) => {
+        const { status, user_is_author: isAuthor } = scenario;
+
+        // This scenario status is "draft", to see it:
+        //  - user must be logged in
+        //  - user must be the author
+        if (status === SCENARIO_STATUS_DRAFT && (!isLoggedIn || !isAuthor)) {
+            return accum;
+        }
+        // This scenario status is "private", to see it:
+        //  - user must be logged in
+        if (status === SCENARIO_STATUS_PRIVATE && !isLoggedIn) {
+            return accum;
+        }
+        accum.push(
             <ScenarioCard
                 key={scenario.id}
                 scenario={scenario}
                 isLoggedIn={isLoggedIn}
             />
         );
-    });
+
+        return accum;
+    }, []);
 };
 
 ScenarioCard.propTypes = {


### PR DESCRIPTION
When logged in as the author of all the scenarios, I can see every scenario I've authored, including "Draft", "Public" and "Private":

![image](https://user-images.githubusercontent.com/27985/71200072-57e6b480-2265-11ea-814e-a602ceabc312.png)

When logged in as someone else, that is not the author, I can see scenarios that are marked "Private": 

![image](https://user-images.githubusercontent.com/27985/71200133-7d73be00-2265-11ea-8e4f-893eb93f2863.png)


When logged out, I can only see scenarios that have been marked as "Public": 

![image](https://user-images.githubusercontent.com/27985/71200096-66cd6700-2265-11ea-84c8-7fd7098e5bbf.png)
