### PR TITLE
Force SSL for the Heroku server

### DIFF
--- a/heroku-server.js
+++ b/heroku-server.js
@@ -1,7 +1,10 @@
 const express = require('express');
 const path = require('path');
+const enforce = require('express-sslify');
+
 const { listener } = require('./server');
 
+listener.use(enforce.HTTPS({ trustProtoHeader: true }));
 listener.use(express.static('./dist'));
 
 listener.get('*', (req, res) => {

--- a/package.json
+++ b/package.json
@@ -48,5 +48,8 @@
     "eslint-plugin-prettier": "^3.1.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^1.18.2"
+  },
+  "dependencies": {
+    "express-sslify": "^1.2.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5254,6 +5254,11 @@ express-session@^1.16.2:
     safe-buffer "5.2.0"
     uid-safe "~2.1.5"
 
+express-sslify@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/express-sslify/-/express-sslify-1.2.0.tgz#30e84bceed1557eb187672bbe1430a0a2a100d9c"
+  integrity sha1-MOhLzu0VV+sYdnK74UMKCioQDZw=
+
 express@^4.17.0, express@^4.17.1:
   version "4.17.1"
   resolved "https://registry.yarnpkg.com/express/-/express-4.17.1.tgz#4491fc38605cf51f8629d39c2b5d026f98a4c134"


### PR DESCRIPTION
This PR uses a library to redirect http requests to https. It turns out that [Heroku doesn't have a built in force-https setting](https://help.heroku.com/J2R1S4T8/can-heroku-force-an-application-to-use-ssl-tls) and they actually recommend using a library. I saw that this one was recommended in a couple places.

Adding the library to the heroku-server.js file will prevent it from affecting our local development environments. To test it locally however, you can run `node heroku-server.js` and visit the site at http://localhost:5000. You will then see that you're redirected to https.