### PR TITLE
Scenario Run: Default body text appears small

### DIFF
--- a/client/components/Scenario/Scenario.css
+++ b/client/components/Scenario/Scenario.css
@@ -4,6 +4,7 @@
 }
 
 .ui.card.scenario__card--run {
+    font-size: 16px;
     width: 93vw;
     min-height: 85vh;
     max-width: 500px;


### PR DESCRIPTION
https://app.asana.com/0/1127815256483386/1152537018034552/f

The default font-size from body {} is 14px. This changes that to 16px