### PR TITLE
Add cohorts and roles auth checks

### DIFF
--- a/client/components/AccountAdmin/index.jsx
+++ b/client/components/AccountAdmin/index.jsx
@@ -20,11 +20,7 @@ class AccountAdmin extends Component {
     }
 
     async getUsers() {
-        const usersResponse = await (await fetch('api/roles')).json();
-        let users = null;
-        if (usersResponse.status === 200) {
-            users = usersResponse.users;
-        }
+        const { users = null } = await (await fetch('api/roles')).json();
 
         this.props.setUsers({ users });
     }

--- a/client/components/Facilitator/Components/Cohorts/CohortScenarios.jsx
+++ b/client/components/Facilitator/Components/Cohorts/CohortScenarios.jsx
@@ -248,7 +248,7 @@ export class CohortScenarios extends React.Component {
                                             className="cohort__table-thead-tbody-tr"
                                             style={{ cursor: 'pointer' }}
                                         >
-                                            <ConfirmAuth requiredPermission="edit_all_cohorts">
+                                            <ConfirmAuth requiredPermission="edit_own_cohorts">
                                                 <Table.Cell
                                                     key={`cell-checkbox-${index}`}
                                                     className="cohort__table-cell-first"

--- a/server/service/cohort/index.js
+++ b/server/service/cohort/index.js
@@ -2,6 +2,7 @@ const { Router } = require('express');
 
 const { validateRequestBody } = require('../../util/requestValidation');
 const { requireUser } = require('../auth/middleware');
+const { requireUserRole } = require('../roles/middleware');
 const { requireUserForRun } = require('../runs/middleware');
 const router = Router();
 
@@ -21,11 +22,24 @@ const {
     doneCohort
 } = require('./endpoints');
 
-router.put('/', [requireUser, validateRequestBody, createCohort]);
+const requiredRoles = ['super_admin', 'admin', 'researcher', 'facilitator'];
+
+router.put('/', [
+    requireUser,
+    requireUserRole(requiredRoles),
+    validateRequestBody,
+    createCohort
+]);
 router.get('/', [requireUser, listUserCohorts]);
-router.post('/:id', [requireUser, validateRequestBody, setCohort]);
+router.post('/:id', [
+    requireUser,
+    requireUserRole(requiredRoles),
+    validateRequestBody,
+    setCohort
+]);
 router.post('/:id/scenarios', [
     requireUser,
+    requireUserRole(requiredRoles),
     validateRequestBody,
     setCohortScenarios
 ]);
@@ -39,7 +53,6 @@ router.get('/:id/participant/:participant_id', [
     getCohortParticipantData
 ]);
 
-// /api/cohort/${id}/run/${runId}
 router.get('/:id/run/:run_id', [requireUserForRun, linkCohortToRun]);
 
 router.get('/:id/join/:role', [requireUser, joinCohort]);

--- a/server/service/roles/index.js
+++ b/server/service/roles/index.js
@@ -15,13 +15,19 @@ const {
     setUserRoles
 } = require('./endpoints');
 
-router.get('/', [requireUserRole('admin'), getAllUsersRoles]);
+router.get('/', [requireUserRole(['admin', 'super_admin']), getAllUsersRoles]);
 
 router.get('/permission', [getUserPermissions]);
 
-router.post('/user/permission', [getUsersByPermission]);
+router.post('/user/permission', [
+    requireUserRole(['admin', 'super_admin']),
+    getUsersByPermission
+]);
 
-router.get('/:user_id', [requireUserRole('admin'), getUserRoles]);
+router.get('/:user_id', [
+    requireUserRole(['admin', 'super_admin']),
+    getUserRoles
+]);
 
 router.put('/:user_id', [
     checkCanEditUserRoles(req => req.params.user_id),

--- a/server/service/roles/middleware.js
+++ b/server/service/roles/middleware.js
@@ -24,7 +24,7 @@ exports.requireUserRole = roles => [
         if (
             // super admin wins - always gets permission for this
             userRoles.includes('super_admin') ||
-            roles.every(role => userRoles.includes(role))
+            roles.some(role => userRoles.includes(role))
         ) {
             return next();
         }
@@ -36,7 +36,7 @@ exports.requireUserRole = roles => [
 
 exports.checkCanEditUserRoles = getEditUserId => [
     // only admin can edit user roles
-    exports.requireUserRole('admin'),
+    exports.requireUserRole(['admin', 'super_admin']),
     asyncMiddleware(async function checkCanEditUser(req, res, next) {
         const targetUserId = await getEditUserId(req);
         const { roles: targetUserRoles } = await db.getUserRoles(targetUserId);


### PR DESCRIPTION
@rwaldron I think more auth check PRs are coming, but didn't want to make them too big. My proposed changes:

- Small amount of refactoring to AccountAdmin
- In CohortScenarios, make sure facilitators and researchers can add scenarios to their cohorts (they should be able to, right?)
- Specify required roles for the cohorts API routes (especially good to confirm I understood their intended roles right)
- Specify required roles for roles API

Tests:
- As an admin confirm you can edit roles in Account Administration
- As a researcher or facilitator confirm you can create and edit your cohort
- As a participant, make sure you can still join cohorts