### PR TITLE
Add auth checks for scenario CRUD operations

### DIFF
--- a/server/service/scenarios/index.js
+++ b/server/service/scenarios/index.js
@@ -1,8 +1,10 @@
 const { Router } = require('express');
 const { requireUser } = require('../auth/middleware');
+const { requireUserRole } = require('../roles/middleware');
 const { validateRequestBody } = require('../../util/requestValidation');
 const { lookupScenario } = require('./middleware');
 
+const requiredRoles = ['super_admin', 'admin', 'researcher', 'facilitator'];
 const router = Router();
 
 const {
@@ -27,18 +29,35 @@ router.get('/:scenario_id/cohort/:cohort_id/history', [
     getScenarioRunHistory
 ]);
 
-router.put('/', [validateRequestBody, addScenario]);
+router.put('/', [
+    requireUserRole(requiredRoles),
+    validateRequestBody,
+    addScenario
+]);
 
 router.post('/:scenario_id', [
+    requireUserRole(requiredRoles),
     lookupScenario(),
     validateRequestBody,
     setScenario
 ]);
 
-router.post('/:scenario_id/copy', [lookupScenario(), copyScenario]);
+router.post('/:scenario_id/copy', [
+    requireUserRole(requiredRoles),
+    lookupScenario(),
+    copyScenario
+]);
 
-router.delete('/:scenario_id', [lookupScenario(), softDeleteScenario]);
-router.delete('/:scenario_id/hard', [lookupScenario(), deleteScenario]);
+router.delete('/:scenario_id', [
+    requireUserRole(['super_admin', 'admin']),
+    lookupScenario(),
+    softDeleteScenario
+]);
+router.delete('/:scenario_id/hard', [
+    requireUserRole(['super_admin', 'admin']),
+    lookupScenario(),
+    deleteScenario
+]);
 
 router.use('/:scenario_id/slides', [lookupScenario(), require('./slides')]);
 

--- a/server/service/scenarios/slides/index.js
+++ b/server/service/scenarios/slides/index.js
@@ -1,6 +1,8 @@
 const { Router } = require('express');
 const { validateRequestBody } = require('../../../util/requestValidation');
+const { requireUserRole } = require('../../roles/middleware');
 
+const requiredRoles = ['super_admin', 'admin', 'researcher', 'facilitator'];
 const slides = new Router();
 const {
     getSlides,
@@ -13,11 +15,27 @@ const {
 } = require('./endpoints');
 
 slides.get('/', getSlides);
-slides.post('/', [validateRequestBody, setAllSlides]);
+slides.post('/', [
+    requireUserRole(requiredRoles),
+    validateRequestBody,
+    setAllSlides
+]);
 slides.get('/response-components', getSlidesPromptComponents);
-slides.put('/', [validateRequestBody, addSlide]);
-slides.post('/order', [validateRequestBody, orderSlides]);
-slides.post('/:slide_id', [validateRequestBody, updateSlide]);
-slides.delete('/:slide_id', deleteSlide);
+slides.put('/', [
+    requireUserRole(requiredRoles),
+    validateRequestBody,
+    addSlide
+]);
+slides.post('/order', [
+    requireUserRole(requiredRoles),
+    validateRequestBody,
+    orderSlides
+]);
+slides.post('/:slide_id', [
+    requireUserRole(requiredRoles),
+    validateRequestBody,
+    updateSlide
+]);
+slides.delete('/:slide_id', [requireUserRole(requiredRoles), deleteSlide]);
 
 module.exports = slides;


### PR DESCRIPTION
@rwaldron this is a follow up to the API auth checks. My proposed changes are to make sure only roles with scenario create permissions should be able to hit certain endpoints. 

Tests:
- As an admin, perform all CRUD operations with a scenario and also slides with in it
- As an facilitator or researcher, perform all CRUD operations with a scenario and also slides with in it