### PR TITLE
ScenarioList: organizing into a "create" and "search" feature for "Scenarios" view

### DIFF
--- a/client/components/Editor/index.jsx
+++ b/client/components/Editor/index.jsx
@@ -375,7 +375,7 @@ EditorMessage.propTypes = {
 };
 
 Editor.propTypes = {
-    author: PropTypes.string,
+    author: PropTypes.object,
     activeTab: PropTypes.string,
     activeSlideIndex: PropTypes.number,
     scenarioId: PropTypes.node,

--- a/client/components/EditorMenu/EditorMenu.css
+++ b/client/components/EditorMenu/EditorMenu.css
@@ -1,4 +1,3 @@
 .editormenu__search--padding {
-    padding-top: 0.25rem;
-    padding-bottom: 0.25rem;
+    padding: 0.428571em 1.14285714em !important;
 }

--- a/client/components/EditorMenu/index.jsx
+++ b/client/components/EditorMenu/index.jsx
@@ -1,97 +1,21 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Icon, Menu, Popup, Search } from 'semantic-ui-react';
+import { Icon, Menu, Popup } from 'semantic-ui-react';
 import ConfirmableDeleteButton from './ConfirmableDeleteButton';
-import _ from 'lodash';
 import './EditorMenu.css';
-
-const initialSearchState = {
-    isLoading: false,
-    results: [],
-    selected: null,
-    value: ''
-};
 
 export default class EditorMenu extends React.Component {
     constructor(props) {
         super(props);
 
         this.state = {
-            mode: 'edit',
-            search: {
-                ...initialSearchState
-            }
+            mode: 'edit'
         };
-
-        this.onEditorMenuResultSelect = this.onEditorMenuResultSelect.bind(
-            this
-        );
-        this.onEditorMenuSearchChange = this.onEditorMenuSearchChange.bind(
-            this
-        );
-    }
-
-    onEditorMenuResultSelect(event, { result }) {
-        const { results } = this.state.search;
-
-        this.setState(
-            {
-                search: {
-                    isLoading: false,
-                    results,
-                    selected: result,
-                    value: result.name
-                }
-            },
-            () => {
-                const { onResultSelect } = this.props.items.search;
-                onResultSelect(
-                    event,
-                    this.state.search,
-                    this.setState.bind(this)
-                );
-            }
-        );
-    }
-
-    onEditorMenuSearchChange(event, { value }) {
-        const { results, selected } = this.state.search;
-
-        const search = {
-            isLoading: true,
-            results,
-            selected,
-            value
-        };
-
-        this.setState({ search }, () => {
-            const { value } = this.state.search;
-            const { onSearchChange } = this.props.items.search;
-
-            if (value.length < 1) {
-                return this.setState(
-                    {
-                        search: {
-                            ...initialSearchState
-                        }
-                    },
-                    () => {
-                        onSearchChange(
-                            event,
-                            this.state.search,
-                            this.setState.bind(this)
-                        );
-                    }
-                );
-            }
-            onSearchChange(event, this.state.search, this.setState.bind(this));
-        });
     }
 
     render() {
         const { type, items } = this.props;
-        const { mode, search } = this.state;
-        const { onEditorMenuResultSelect, onEditorMenuSearchChange } = this;
+        const { mode } = this.state;
 
         return (
             <Menu icon>
@@ -182,34 +106,6 @@ export default class EditorMenu extends React.Component {
                         />
                     ))}
 
-                {items.search && (
-                    <Popup
-                        content={`Search ${type}`}
-                        trigger={
-                            <Menu.Item
-                                aria-label={`Search ${type}`}
-                                name={`search-${type}`}
-                                className="editormenu__search--padding"
-                            >
-                                <Search
-                                    loading={search.isLoading}
-                                    resultRenderer={items.search.renderer}
-                                    onResultSelect={onEditorMenuResultSelect}
-                                    onSearchChange={_.debounce(
-                                        onEditorMenuSearchChange,
-                                        500,
-                                        {
-                                            leading: true
-                                        }
-                                    )}
-                                    results={search.results}
-                                    value={search.value}
-                                />
-                            </Menu.Item>
-                        }
-                    />
-                )}
-
                 {items.right && (
                     <React.Fragment>
                         {items.right
@@ -228,7 +124,7 @@ export default class EditorMenu extends React.Component {
     }
 }
 
-const VALID_PROPS = ['delete', 'editable', 'left', 'right', 'save', 'search'];
+const VALID_PROPS = ['delete', 'editable', 'left', 'right', 'save'];
 EditorMenu.propTypes = {
     items: function(props, propName) {
         const { items } = props;
@@ -273,23 +169,6 @@ EditorMenu.propTypes = {
             }
             if (items.right && !Array.isArray(items.right)) {
                 return new Error('EditorMenu: Invalid items.right property');
-            }
-
-            if (items.search) {
-                if (
-                    !Object.keys(items.search).every(key =>
-                        [
-                            'onResultSelect',
-                            'onSearchChange',
-                            'renderer',
-                            'source'
-                        ].includes(key)
-                    )
-                ) {
-                    return new Error(
-                        'EditorMenu: Invalid items.search property'
-                    );
-                }
             }
         }
 

--- a/client/components/Facilitator/Components/Cohorts/Cohort.css
+++ b/client/components/Facilitator/Components/Cohorts/Cohort.css
@@ -43,9 +43,8 @@
     margin: 0 !important;
 }
 
-.cohort__menu-item--padding {
-    padding-top: 0.25rem;
-    padding-bottom: 0.25rem;
+.cohorts__menu-item--padding {
+    padding: 0.428571em 1.14285714em !important;
 }
 
 .cohort__table--constraints {

--- a/client/components/Facilitator/Components/Cohorts/CohortCard.jsx
+++ b/client/components/Facilitator/Components/Cohorts/CohortCard.jsx
@@ -25,8 +25,12 @@ const mapStateToProps = (state, props) => {
     const {
         cohort: { userCohorts: cohorts }
     } = state;
-    const { id, name, role } = cohorts.find(cohort => cohort.id === props.id);
-    return { id, name, role };
+    const cohort = cohorts.find(cohort => cohort.id === props.id);
+    const scenarios = cohort.scenarios.map(id =>
+        state.scenarios.find(scenario => scenario.id === id)
+    );
+
+    return { ...cohort, scenarios };
 };
 
 export default connect(mapStateToProps)(CohortCard);

--- a/client/components/ScenarioEditor/DropdownOptions.jsx
+++ b/client/components/ScenarioEditor/DropdownOptions.jsx
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 import { Dropdown, Form } from 'semantic-ui-react';
 
 export const CategoriesDropdown = ({
-    categoryOptions,
-    scenarioCategories,
+    options,
+    categories,
     onChange
 }) => {
     return (
@@ -17,19 +17,29 @@ export const CategoriesDropdown = ({
                 fluid
                 multiple
                 selection
-                options={categoryOptions.map(category => ({
+                options={options.map(category => ({
                     key: category.id,
                     text: category.name,
                     value: category.name
                 }))}
-                defaultValue={scenarioCategories}
+                defaultValue={categories}
                 onChange={onChange}
             />
         </Form.Field>
     );
 };
 
-export const AuthorDropdown = ({ authorOptions, scenarioAuthor, onChange }) => {
+export const AuthorDropdown = ({ options, author = {}, onChange }) => {
+    const onAuthorChange = (event, { name, value: id }) => {
+        const value = options.find(author => author.id === id);
+        onChange(event, {
+            name, value
+        });
+    };
+    const {
+        id: defaultValue
+    } = author;
+
     return (
         <Form.Field>
             <label>Author</label>
@@ -40,26 +50,26 @@ export const AuthorDropdown = ({ authorOptions, scenarioAuthor, onChange }) => {
                 fluid
                 multiple={false}
                 selection
-                options={authorOptions.map(author => ({
+                options={options.map(author => ({
                     key: author.id,
                     text: author.username,
-                    value: author.username
+                    value: author.id
                 }))}
-                defaultValue={scenarioAuthor}
-                onChange={onChange}
+                defaultValue={defaultValue}
+                onChange={onAuthorChange}
             />
         </Form.Field>
     );
 };
 
 CategoriesDropdown.propTypes = {
-    categoryOptions: PropTypes.array.isRequired,
-    scenarioCategories: PropTypes.array.isRequired,
+    categories: PropTypes.array.isRequired,
+    options: PropTypes.array.isRequired,
     onChange: PropTypes.func.isRequired
 };
 
 AuthorDropdown.propTypes = {
-    authorOptions: PropTypes.array.isRequired,
-    scenarioAuthor: PropTypes.string,
+    author: PropTypes.object,
+    options: PropTypes.array.isRequired,
     onChange: PropTypes.func.isRequired
 };

--- a/client/components/ScenarioEditor/index.jsx
+++ b/client/components/ScenarioEditor/index.jsx
@@ -296,22 +296,22 @@ class ScenarioEditor extends Component {
                                 className="scenarioeditor__grid-column-min-width"
                             >
                                 <ConfirmAuth requiredPermission="edit_scenario">
-                                    {this.state.authors.length && (
+                                    {this.state.authors.length ? (
                                         <AuthorDropdown
-                                            scenarioAuthor={author.username}
-                                            authorOptions={this.state.authors}
+                                            author={author}
+                                            options={this.state.authors}
                                             onChange={onChange}
                                         />
-                                    )}
-                                    {this.state.categories.length && (
+                                    ) : null}
+                                    {this.state.categories.length ? (
                                         <CategoriesDropdown
-                                            categoryOptions={
+                                            options={
                                                 this.state.categories
                                             }
-                                            scenarioCategories={categories}
+                                            categories={categories}
                                             onChange={onChange}
                                         />
-                                    )}
+                                    ) : null}
                                 </ConfirmAuth>
 
                                 {/*

--- a/client/components/ScenarioEditor/index.jsx
+++ b/client/components/ScenarioEditor/index.jsx
@@ -42,7 +42,7 @@ class ScenarioEditor extends Component {
 
         if (this.props.scenarioId === 'new') {
             this.props.setScenario({
-                author: '',
+                author: {},
                 title: '',
                 description: '',
                 finish: {
@@ -298,7 +298,7 @@ class ScenarioEditor extends Component {
                                 <ConfirmAuth requiredPermission="edit_scenario">
                                     {this.state.authors.length && (
                                         <AuthorDropdown
-                                            scenarioAuthor={author}
+                                            scenarioAuthor={author.username}
                                             authorOptions={this.state.authors}
                                             onChange={onChange}
                                         />
@@ -383,7 +383,7 @@ ScenarioEditor.propTypes = {
     submitCB: PropTypes.func.isRequired,
     postSubmitCB: PropTypes.func,
     updateEditorMessage: PropTypes.func.isRequired,
-    author: PropTypes.string,
+    author: PropTypes.object,
     title: PropTypes.string,
     categories: PropTypes.array,
     consent: PropTypes.shape({

--- a/client/components/ScenariosList/ScenariosList.css
+++ b/client/components/ScenariosList/ScenariosList.css
@@ -14,3 +14,7 @@
     max-height: 10rem !important;
     overflow-y: auto !important;
 }
+
+.scenarios__menu-item--padding {
+    padding: 0.428571em 1.14285714em !important;
+}

--- a/client/reducers/scenario.js
+++ b/client/reducers/scenario.js
@@ -19,7 +19,10 @@ import {
 const initialScenarioState = {
     title: '',
     description: '',
-    author: '',
+    author: {
+        id: null,
+        username: ''
+    },
     consent: {
         id: null,
         prose: ''

--- a/client/routes/Navigation.jsx
+++ b/client/routes/Navigation.jsx
@@ -11,11 +11,6 @@ Session.timeout();
 const MOBILE_WIDTH = 767;
 const restrictedNav = [
     {
-        text: 'Create a Scenario',
-        path: '/editor/new',
-        permission: 'create_scenario'
-    },
-    {
         text: 'My Scenario Data',
         path: '/my-scenario-data',
         permission: 'view_own_data'

--- a/server/service/auth/db.js
+++ b/server/service/auth/db.js
@@ -13,6 +13,21 @@ async function getUserByProps({ id, username, email }) {
 }
 
 exports.getUserByProps = getUserByProps;
+
+exports.getUserForClientByProps = async function(props) {
+    let {
+        id,
+        email,
+        username
+    } = await getUserByProps(props);
+
+    return {
+        id,
+        email,
+        username,
+    };
+};
+
 exports.createUser = async function({ email, username, password }) {
     let salt, passwordHash;
     if (password) {

--- a/server/service/roles/endpoints.js
+++ b/server/service/roles/endpoints.js
@@ -1,7 +1,6 @@
-const { asyncMiddleware } = require('../../util/api');
-
 const db = require('./db');
-const { getUserByProps } = require('../auth/db');
+const { asyncMiddleware } = require('../../util/api');
+const { getUserForClientByProps } = require('../auth/db');
 
 exports.getAllUsersRoles = asyncMiddleware(async function getAllUserRolesAsync(
     req,
@@ -55,7 +54,7 @@ exports.addUserRoles = asyncMiddleware(async function addUserRolesAsync(
     res
 ) {
     const { id, roles } = req.body;
-    const user = await getUserByProps({ id });
+    const user = await getUserForClientByProps({ id });
     const userId = user.id;
     if (!userId || !roles.length) {
         const roleCreateError = new Error('User and roles must be defined');
@@ -81,7 +80,7 @@ exports.deleteUserRoles = asyncMiddleware(async function deleteUserRolesAsync(
     res
 ) {
     const { id, roles } = req.body;
-    const user = await getUserByProps({ id });
+    const user = await getUserForClientByProps({ id });
     const userId = user.id;
     if (!userId || !roles.length) {
         const error = new Error('User and roles must be defined');

--- a/server/service/scenarios/db.js
+++ b/server/service/scenarios/db.js
@@ -74,7 +74,7 @@ async function getScenario(scenarioId) {
     `);
 
     const { author_id } = results.rows[0];
-    const { username: author } = await getUserByProps({ id: author_id });
+    const author = await getUserByProps({ id: author_id });
     const categories = await getScenarioCategories(scenarioId);
     const consent = await getScenarioConsent(scenarioId);
     const finish =
@@ -99,13 +99,20 @@ async function getAllScenarios() {
 
     const scenarios = [];
     for (const row of results.rows) {
+        const author = await getUserByProps({ id: row.author_id });
         const categories = await getScenarioCategories(row.id);
         const consent = await getScenarioConsent(row.id);
         const finish =
             (await getSlidesForScenario(row.id)).find(
                 slide => slide.is_finish
             ) || (await addFinishSlide(row.id));
-        scenarios.push({ ...row, categories, consent, finish });
+        scenarios.push({
+            ...row,
+            author,
+            categories,
+            consent,
+            finish
+        });
     }
 
     return scenarios;

--- a/server/service/scenarios/db.js
+++ b/server/service/scenarios/db.js
@@ -2,7 +2,7 @@ const { sql, updateQuery } = require('../../util/sqlHelpers');
 const { query } = require('../../util/db');
 const { addSlide, getSlidesForScenario } = require('./slides/db');
 const { getRunResponses } = require('../runs/db');
-const { getUserByProps } = require('../auth/db');
+const { getUserForClientByProps } = require('../auth/db');
 
 async function getScenarioCategories(scenarioId) {
     const scenarioCategoriesResults = await query(sql`
@@ -74,7 +74,7 @@ async function getScenario(scenarioId) {
     `);
 
     const { author_id } = results.rows[0];
-    const author = await getUserByProps({ id: author_id });
+    const author = await getUserForClientByProps({ id: author_id });
     const categories = await getScenarioCategories(scenarioId);
     const consent = await getScenarioConsent(scenarioId);
     const finish =
@@ -99,7 +99,7 @@ async function getAllScenarios() {
 
     const scenarios = [];
     for (const row of results.rows) {
-        const author = await getUserByProps({ id: row.author_id });
+        const author = await getUserForClientByProps({ id: row.author_id });
         const categories = await getScenarioCategories(row.id);
         const consent = await getScenarioConsent(row.id);
         const finish =

--- a/server/service/scenarios/endpoints.js
+++ b/server/service/scenarios/endpoints.js
@@ -1,8 +1,8 @@
 const uuid = require('uuid/v4');
 const { asyncMiddleware } = require('../../util/api');
-const { getUserByProps } = require('../auth/db');
-
+const { getUserForClientByProps } = require('../auth/db');
 const { reqScenario } = require('./middleware');
+
 const {
     addSlide,
     getSlidesForScenario,
@@ -39,10 +39,7 @@ exports.getAllScenarios = asyncMiddleware(async function getAllScenariosAsync(
     }
 });
 
-exports.addScenario = asyncMiddleware(async function addScenarioAsync(
-    req,
-    res
-) {
+async function addScenarioAsync(req, res) {
     const userId = req.session.user.id;
     const { author, title, description, categories } = req.body;
     let authorId = userId;
@@ -55,9 +52,8 @@ exports.addScenario = asyncMiddleware(async function addScenarioAsync(
         throw scenarioCreateError;
     }
 
-    if (author) {
-        const { id } = await getUserByProps({ username: author });
-        authorId = id;
+    if (author && author.id) {
+        authorId = author.id;
     }
 
     try {
@@ -72,7 +68,7 @@ exports.addScenario = asyncMiddleware(async function addScenarioAsync(
         error.stack = apiError.stack;
         throw error;
     }
-});
+};
 
 async function setScenarioAsync(req, res) {
     const {
@@ -89,9 +85,8 @@ async function setScenarioAsync(req, res) {
     const scenarioId = req.params.scenario_id;
     let authorId = author_id;
 
-    if (author) {
-        const { id } = await getUserByProps({ username: author });
-        authorId = id || author_id;
+    if (author && author.id) {
+        authorId = author.id || author_id;
     }
 
     if (!authorId && !title && !description) {
@@ -159,6 +154,7 @@ async function setScenarioAsync(req, res) {
     }
 }
 
+exports.addScenario = asyncMiddleware(addScenarioAsync);
 exports.setScenario = asyncMiddleware(setScenarioAsync);
 
 exports.deleteScenario = asyncMiddleware(async function deleteScenarioAsync(


### PR DESCRIPTION
Most notable changes: 

- The "Create a Scenario" menu item didn't really belong in the main menu; that's not moved into "Scenarios" view (matches "Cohorts")
- "Scenarios" view has a new "search" capability (matches "Cohorts")



![image](https://user-images.githubusercontent.com/27985/72222226-7708f700-3530-11ea-8246-ce290ac0bce4.png)

![image](https://user-images.githubusercontent.com/27985/72222229-7c664180-3530-11ea-9a91-59e1d44c971f.png)

![image](https://user-images.githubusercontent.com/27985/72222232-825c2280-3530-11ea-9094-9af755754304.png)

![image](https://user-images.githubusercontent.com/27985/72222236-85571300-3530-11ea-88f2-72346fa83560.png)
