### PR TITLE
Explicitly set the default application language

### DIFF
--- a/client/static/index.html
+++ b/client/static/index.html
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title></title>
     <meta charset="UTF-8">
+    <meta name="google" content="notranslate">
+    <meta http-equiv="Content-Language" content="en">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" type="text/css" href="/root-styles.css">
 </head>


### PR DESCRIPTION
This will prevent Chrome from erroneously attempting to translate the page 